### PR TITLE
Migrate to `compose_spec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "compose_spec"
 version = "0.2.0-alpha.1"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#1aa212daa743c0deeedb12954e7e56d125643dfc"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#ce35bbc02b46c5afcc469129249cb4f0d18778ff"
 dependencies = [
  "compose_spec_macros",
  "indexmap",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "compose_spec_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#1aa212daa743c0deeedb12954e7e56d125643dfc"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#ce35bbc02b46c5afcc469129249cb4f0d18778ff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "compose_spec"
+version = "0.1.1-beta.1"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git#d268ea691cda807cd027e61cc3fea45110c13129"
+dependencies = [
+ "compose_spec_macros",
+ "indexmap",
+ "ipnet",
+ "itoa",
+ "serde",
+ "serde_yaml",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "compose_spec_macros"
+version = "0.1.0"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git#d268ea691cda807cd027e61cc3fea45110c13129"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,9 +763,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -982,6 +1007,7 @@ version = "0.2.4"
 dependencies = [
  "clap",
  "color-eyre",
+ "compose_spec",
  "duration-str",
  "indexmap",
  "ipnet",
@@ -1543,6 +1569,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,17 +501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "duration-str"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bb6a301a95ba86fa0ebaf71d49ae4838c51f8b84cb88ed140dfb66452bb3c4"
-dependencies = [
- "nom",
- "rust_decimal",
- "thiserror",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,12 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,16 +876,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1008,7 +975,6 @@ dependencies = [
  "clap",
  "color-eyre",
  "compose_spec",
- "duration-str",
  "indexmap",
  "ipnet",
  "k8s-openapi",
@@ -1156,16 +1122,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "rust_decimal"
-version = "1.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
-dependencies = [
- "arrayvec",
- "num-traits",
-]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "compose_spec"
 version = "0.2.0-alpha.1"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#5650cd69d9105e7a2f9c130ee0e92757eb207023"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#a92a76c5280d4e4bfd89d67ec52e3f08e92cbba0"
 dependencies = [
  "compose_spec_macros",
  "indexmap",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "compose_spec_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#5650cd69d9105e7a2f9c130ee0e92757eb207023"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#a92a76c5280d4e4bfd89d67ec52e3f08e92cbba0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "nix",
  "path-clean",
  "serde",
+ "serde_json",
  "serde_yaml",
  "shlex",
  "smart-default",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "compose_spec"
 version = "0.2.0-alpha.1"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#a92a76c5280d4e4bfd89d67ec52e3f08e92cbba0"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#1aa212daa743c0deeedb12954e7e56d125643dfc"
 dependencies = [
  "compose_spec_macros",
  "indexmap",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "compose_spec_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#a92a76c5280d4e4bfd89d67ec52e3f08e92cbba0"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#1aa212daa743c0deeedb12954e7e56d125643dfc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,8 +428,8 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compose_spec"
-version = "0.1.1-beta.1"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git#d268ea691cda807cd027e61cc3fea45110c13129"
+version = "0.2.0-alpha.1"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#5650cd69d9105e7a2f9c130ee0e92757eb207023"
 dependencies = [
  "compose_spec_macros",
  "indexmap",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "compose_spec_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git#d268ea691cda807cd027e61cc3fea45110c13129"
+source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#5650cd69d9105e7a2f9c130ee0e92757eb207023"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,41 +461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,37 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660047478bc508c0fde22c868991eec0c40a63e48d610befef466d48e2bee574"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b217e6dd1011a54d12f3b920a411b5abd44b1716ecfe94f5f2f2f7b52e08ab7"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5f77d7e20ac9153428f7ca14a88aba652adfc7a0ef0a06d654386310ef663b"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,18 +479,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "docker-compose-types"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e366950e7785fe0e404901a2b4e5c09ebd6656767f0c2167e34c5068ce0cc2d"
-dependencies = [
- "derive_builder",
- "indexmap",
- "serde",
- "serde_yaml",
 ]
 
 [[package]]
@@ -669,12 +591,6 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -803,12 +719,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1072,7 +982,6 @@ version = "0.2.4"
 dependencies = [
  "clap",
  "color-eyre",
- "docker-compose-types",
  "duration-str",
  "indexmap",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,8 +422,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.0-alpha.1"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#ce35bbc02b46c5afcc469129249cb4f0d18778ff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11eaf64d1b140e01bb3717dd714bad4f5d58ecf6af41d731bc1e4d9e6b78089e"
 dependencies = [
  "compose_spec_macros",
  "indexmap",
@@ -438,7 +439,8 @@ dependencies = [
 [[package]]
 name = "compose_spec_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/k9withabone/compose_spec_rs.git?branch=compose_spec-v0.2.0#ce35bbc02b46c5afcc469129249cb4f0d18778ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b81b28b4697353a547b8ab24376c3bfe6f8eea6ad2e8f434641488864d997c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ verbose_file_reads = "warn"
 [dependencies]
 clap = { version = "4.2", features = ["derive", "wrap_help"] }
 color-eyre = "0.6"
-compose_spec = { version = "0.1.1-beta.1", git = "ssh://git@github.com/k9withabone/compose_spec_rs.git" }
+compose_spec = { version = "0.2.0-alpha.1", git = "ssh://git@github.com/k9withabone/compose_spec_rs.git", branch = "compose_spec-v0.2.0" }
 duration-str = { version = "0.7", default-features = false }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ ipnet = { version = "2.7", features = ["serde"] }
 k8s-openapi = { version = "0.21", features = ["latest"] }
 path-clean = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9.21"
 shlex = "1.3"
 smart-default = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ verbose_file_reads = "warn"
 clap = { version = "4.2", features = ["derive", "wrap_help"] }
 color-eyre = "0.6"
 compose_spec = { version = "0.2.0-alpha.1", git = "ssh://git@github.com/k9withabone/compose_spec_rs.git", branch = "compose_spec-v0.2.0" }
-duration-str = { version = "0.7", default-features = false }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2.7", features = ["serde"] }
 k8s-openapi = { version = "0.21", features = ["latest"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,8 @@ verbose_file_reads = "warn"
 [dependencies]
 clap = { version = "4.2", features = ["derive", "wrap_help"] }
 color-eyre = "0.6"
-docker-compose-types = "0.7.0"
 duration-str = { version = "0.7", default-features = false }
-indexmap = "2"
+indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2.7", features = ["serde"] }
 k8s-openapi = { version = "0.21", features = ["latest"] }
 path-clean = "1"
@@ -90,7 +89,13 @@ cargo-dist-version = "0.8.1"
 # CI backends to support
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-msvc",
+]
 # The installers to generate for each app
 installers = []
 # Publish jobs to run in CI
@@ -132,9 +137,9 @@ footer = """
 """
 # postprocessors
 postprocessors = [
-  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"}, # replace issue numbers
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))" }, # replace issue numbers
   { pattern = '<REPO>', replace = "https://github.com/k9withabone/podlet" },
-  { pattern = '### \pN+ ', replace = "### " } # remove numbers from groups
+  { pattern = '### \pN+ ', replace = "### " },                                      # remove numbers from groups
 ]
 
 [workspace.metadata.git-cliff.git]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ verbose_file_reads = "warn"
 [dependencies]
 clap = { version = "4.2", features = ["derive", "wrap_help"] }
 color-eyre = "0.6"
+compose_spec = { version = "0.1.1-beta.1", git = "ssh://git@github.com/k9withabone/compose_spec_rs.git" }
 duration-str = { version = "0.7", default-features = false }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ verbose_file_reads = "warn"
 [dependencies]
 clap = { version = "4.2", features = ["derive", "wrap_help"] }
 color-eyre = "0.6"
-compose_spec = { version = "0.2.0-alpha.1", git = "ssh://git@github.com/k9withabone/compose_spec_rs.git", branch = "compose_spec-v0.2.0" }
+compose_spec = "0.2"
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2.7", features = ["serde"] }
 k8s-openapi = { version = "0.21", features = ["latest"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -349,7 +349,10 @@ enum Commands {
     Compose {
         /// Create a Kubernetes YAML file for a pod instead of separate containers
         ///
-        /// A `.kube` file using the generated Kubernetes YAML file will also be created.
+        /// A `.kube` file using the generated Kubernetes YAML file is also created.
+        ///
+        /// The top-level `name` field in the compose file is required when using this option.
+        /// It is used for the name of the pod and in the filenames of the created files.
         #[arg(long)]
         kube: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -397,6 +397,8 @@ impl Commands {
                 .into_quadlet(name, unit, (*global_args).into(), install)
                 .into()]),
             Self::Compose { pod, compose_file } => {
+                todo!()
+                /*
                 let compose = compose::from_file_or_stdin(compose_file.as_deref())?;
 
                 eyre::ensure!(
@@ -433,6 +435,7 @@ impl Commands {
                         .map(|result| result.map(Into::into))
                         .collect()
                 }
+                */
             }
             Self::Generate(command) => {
                 Ok(vec![command.try_into_quadlet(name, unit, install)?.into()])
@@ -502,11 +505,14 @@ impl TryFrom<ComposeService> for PodmanCommands {
     type Error = color_eyre::Report;
 
     fn try_from(value: ComposeService) -> Result<Self, Self::Error> {
+        todo!()
+        /*
         let service = (&value.service).try_into()?;
         Ok(Self::Run {
             container: Box::new(value.try_into()?),
             service,
         })
+        */
     }
 }
 
@@ -704,7 +710,7 @@ impl Downgrade for File {
 
 #[derive(Debug)]
 struct ComposeService {
-    service: docker_compose_types::Service,
+    // service: docker_compose_types::Service,
     volume_has_options: Rc<HashMap<String, bool>>,
 }
 

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -14,7 +14,7 @@ use compose_spec::{Compose, Identifier, Network, Networks, Resource, Service, Vo
 
 use crate::quadlet::{self, container::volume::Source, Globals};
 
-use super::{Container, Unit};
+use super::{Container, GlobalArgs, Unit};
 
 /// Deserialize [`Compose`] from a file at the given [`Path`], stdin, or a list of default files.
 ///
@@ -183,6 +183,8 @@ fn service_try_into_quadlet_file(
         }
     }
 
+    let global_args = GlobalArgs::from_compose(&mut service);
+
     let restart = service.restart;
 
     let mut container = Container::try_from(service)
@@ -208,7 +210,7 @@ fn service_try_into_quadlet_file(
         name: name.into(),
         unit,
         resource: container.into(),
-        globals: Globals::default(),
+        globals: global_args.into(),
         service: restart.map(Into::into),
         install,
     })

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -10,12 +10,13 @@ use color_eyre::{
     eyre::{self, OptionExt, WrapErr},
     Help,
 };
-use docker_compose_types::{Command, Compose, ComposeNetworks, MapOrEmpty};
+// use docker_compose_types::{Command, Compose, ComposeNetworks, MapOrEmpty};
 
 use crate::quadlet::{self, Globals};
 
 use super::{image_to_name, unit::Unit, ComposeService, PodmanCommands};
 
+/*
 /// Read a [`Compose`] from a file at the given [`Path`], stdin, or a list of default files.
 ///
 /// If the path is '-', or stdin is not a terminal, the [`Compose`] is read from stdin.
@@ -230,3 +231,4 @@ fn volumes_try_into_quadlet_files<'a>(
         })
     })
 }
+*/

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -10,7 +10,9 @@ use color_eyre::{
     eyre::{bail, eyre, OptionExt, WrapErr},
     Help,
 };
-use compose_spec::{Compose, Identifier, Network, Networks, Resource, Service, Volumes};
+use compose_spec::{
+    service::Command, Compose, Identifier, Network, Networks, Resource, Service, Volumes,
+};
 
 use crate::quadlet::{self, container::volume::Source, Globals};
 
@@ -84,8 +86,8 @@ fn from_stdin() -> color_eyre::Result<Compose> {
     serde_yaml::from_reader(stdin).wrap_err("data from stdin is not a valid compose file")
 }
 
-/*
-/// Converts a [`Command`] into a `Vec<String>`, splitting the `String` variant as a shell would.
+/// Converts a [`Command`] into a [`Vec<String>`], splitting the [`String`](Command::String) variant
+/// as a shell would.
 ///
 /// # Errors
 ///
@@ -93,16 +95,15 @@ fn from_stdin() -> color_eyre::Result<Compose> {
 /// has a trailing unescaped '\\'.
 pub fn command_try_into_vec(command: Command) -> color_eyre::Result<Vec<String>> {
     match command {
-        Command::Simple(s) => shlex::split(&s)
-            .ok_or_else(|| eyre::eyre!("invalid command: `{s}`"))
+        Command::String(command) => shlex::split(&command)
+            .ok_or_else(|| eyre!("invalid command: `{command}`"))
             .suggestion(
                 "In the command, make sure quotes are closed properly and there are no \
-                trailing \\. Alternatively, use an array instead of a string.",
+                    trailing \\. Alternatively, use an array instead of a string.",
             ),
-        Command::Args(args) => Ok(args),
+        Command::List(command) => Ok(command),
     }
 }
-*/
 
 /// Attempt to convert a [`Compose`] file into an [`Iterator`] of [`quadlet::File`]s.
 ///

--- a/src/cli/container.rs
+++ b/src/cli/container.rs
@@ -47,6 +47,8 @@ impl TryFrom<ComposeService> for Container {
     type Error = color_eyre::Report;
 
     fn try_from(mut value: ComposeService) -> Result<Self, Self::Error> {
+        todo!()
+        /*
         let service = &value.service;
         let unsupported_options = [
             ("deploy", service.deploy.is_none()),
@@ -92,6 +94,7 @@ impl TryFrom<ComposeService> for Container {
                 .transpose()?
                 .unwrap_or_default(),
         })
+        */
     }
 }
 

--- a/src/cli/container.rs
+++ b/src/cli/container.rs
@@ -10,7 +10,8 @@ use color_eyre::eyre::{self, Context, OptionExt};
 use crate::{cli::compose, escape::command_join};
 
 use self::{podman::PodmanArgs, quadlet::QuadletOptions, security_opt::SecurityOpt};
-use super::{image_to_name, ComposeService};
+
+use super::image_to_name;
 
 #[derive(Args, Default, Debug, Clone, PartialEq)]
 pub struct Container {
@@ -43,10 +44,22 @@ pub struct Container {
     command: Vec<String>,
 }
 
-impl TryFrom<ComposeService> for Container {
+impl Container {
+    /// The name that should be used for the generated [`File`](crate::quadlet::File).
+    ///
+    /// It is either the set container name or taken from the image.
+    pub fn name(&self) -> &str {
+        self.quadlet_options
+            .name
+            .as_deref()
+            .unwrap_or_else(|| image_to_name(&self.image))
+    }
+}
+
+impl TryFrom<compose_spec::Service> for Container {
     type Error = color_eyre::Report;
 
-    fn try_from(mut value: ComposeService) -> Result<Self, Self::Error> {
+    fn try_from(mut value: compose_spec::Service) -> Result<Self, Self::Error> {
         todo!()
         /*
         let service = &value.service;
@@ -155,15 +168,6 @@ impl From<Container> for crate::quadlet::Container {
 impl From<Container> for crate::quadlet::Resource {
     fn from(value: Container) -> Self {
         crate::quadlet::Container::from(value).into()
-    }
-}
-
-impl Container {
-    pub fn name(&self) -> &str {
-        self.quadlet_options
-            .name
-            .as_deref()
-            .unwrap_or_else(|| image_to_name(&self.image))
     }
 }
 

--- a/src/cli/container/compose.rs
+++ b/src/cli/container/compose.rs
@@ -1,0 +1,383 @@
+//! Types for splitting up a [`compose_spec::Service`] into parts and constructing a
+//! [`Container`](super::Container).
+
+use std::{net::IpAddr, path::PathBuf, time::Duration};
+
+use color_eyre::eyre::ensure;
+use compose_spec::{
+    service::{
+        build::Context, device::CgroupRule, BlkioConfig, Build, ByteValue, Cgroup, Command,
+        ConfigOrSecret, CpuSet, Cpus, CredentialSpec, Deploy, Develop, Device, EnvFile, Expose,
+        Extends, Healthcheck, Hostname, Image, Ipc, Limit, Link, Logging, MacAddress,
+        NetworkConfig, OomScoreAdj, Percent, Platform, Ports, PullPolicy, Ulimits, UserOrGroup,
+        Uts, Volumes, VolumesFrom,
+    },
+    Extensions, Identifier, ItemOrList, ListOrMap, MapKey, ShortOrLong, StringOrNumber,
+};
+use indexmap::{IndexMap, IndexSet};
+
+/// A struct for splitting up a [`compose_spec::Service`] into parts used to construct a
+/// [`Container`](super::Container).
+pub struct Service {
+    pub unsupported: Unsupported,
+    pub quadlet: Quadlet,
+    pub podman_args: PodmanArgs,
+    pub container: Container,
+}
+
+impl From<compose_spec::Service> for Service {
+    fn from(
+        compose_spec::Service {
+            attach,
+            build,
+            blkio_config,
+            cpu_count,
+            cpu_percent,
+            cpu_shares,
+            cpu_period,
+            cpu_quota,
+            cpu_rt_runtime,
+            cpu_rt_period,
+            cpus,
+            cpuset,
+            cap_add,
+            cap_drop,
+            cgroup,
+            cgroup_parent,
+            command,
+            configs,
+            container_name,
+            credential_spec,
+            // Taken in `crate::cli::compose::service_try_into_quadlet_file()`.
+            depends_on: _,
+            deploy,
+            develop,
+            device_cgroup_rules,
+            devices,
+            dns,
+            dns_opt,
+            dns_search,
+            domain_name,
+            entrypoint,
+            env_file,
+            environment,
+            expose,
+            extends,
+            annotations,
+            external_links,
+            extra_hosts,
+            group_add,
+            healthcheck,
+            hostname,
+            image,
+            init,
+            ipc,
+            uts,
+            isolation,
+            labels,
+            links,
+            logging,
+            network_config,
+            mac_address,
+            mem_limit,
+            mem_reservation,
+            mem_swappiness,
+            memswap_limit,
+            oom_kill_disable,
+            oom_score_adj,
+            pid,
+            pids_limit,
+            platform,
+            ports,
+            privileged,
+            profiles,
+            pull_policy,
+            read_only,
+            // Taken for the `[Service]` section.
+            restart: _,
+            // Taken in `crate::cli::GlobalArgs::from_compose()`.
+            runtime: _,
+            scale,
+            secrets,
+            security_opt,
+            shm_size,
+            stdin_open,
+            stop_grace_period,
+            stop_signal,
+            // Taken in `crate::cli::GlobalArgs::from_compose()`.
+            storage_opt: _,
+            sysctls,
+            tmpfs,
+            tty,
+            ulimits,
+            user,
+            userns_mode,
+            volumes,
+            volumes_from,
+            working_dir,
+            extensions,
+        }: compose_spec::Service,
+    ) -> Self {
+        let Logging {
+            driver: log_driver,
+            options: log_options,
+            extensions: logging_extensions,
+        } = logging.unwrap_or_default();
+
+        Self {
+            unsupported: Unsupported {
+                attach,
+                build,
+                cpu_count,
+                cpu_percent,
+                configs,
+                credential_spec,
+                deploy,
+                develop,
+                domain_name,
+                extends,
+                external_links,
+                isolation,
+                links,
+                logging_extensions,
+                memswap_limit,
+                profiles,
+                scale,
+                volumes_from,
+                extensions,
+            },
+            quadlet: Quadlet {
+                cap_add,
+                cap_drop,
+                container_name,
+                devices,
+                dns,
+                dns_opt,
+                dns_search,
+                env_file,
+                environment,
+                expose,
+                annotations,
+                healthcheck,
+                hostname,
+                init,
+                labels,
+                log_driver,
+                network_config,
+                pids_limit,
+                ports,
+                pull_policy,
+                read_only,
+                secrets,
+                shm_size,
+                sysctls,
+                tmpfs,
+                ulimits,
+                user,
+                userns_mode,
+                volumes,
+                working_dir,
+            },
+            podman_args: PodmanArgs {
+                blkio_config,
+                cpu_shares,
+                cpu_period,
+                cpu_quota,
+                cpu_rt_runtime,
+                cpu_rt_period,
+                cpus,
+                cpuset,
+                cgroup,
+                cgroup_parent,
+                device_cgroup_rules,
+                entrypoint,
+                extra_hosts,
+                group_add,
+                ipc,
+                uts,
+                log_options,
+                mac_address,
+                mem_limit,
+                mem_reservation,
+                mem_swappiness,
+                oom_kill_disable,
+                oom_score_adj,
+                pid,
+                platform,
+                privileged,
+                stdin_open,
+                stop_grace_period,
+                stop_signal,
+                tty,
+            },
+            container: Container {
+                command,
+                image,
+                security_opt,
+            },
+        }
+    }
+}
+
+/// Fields taken from a [`compose_spec::Service`] which are not supported.
+pub struct Unsupported {
+    attach: bool,
+    build: Option<ShortOrLong<Context, Build>>,
+    cpu_count: Option<u64>,
+    cpu_percent: Option<Percent>,
+    configs: Vec<ShortOrLong<Identifier, ConfigOrSecret>>,
+    credential_spec: Option<CredentialSpec>,
+    deploy: Option<Deploy>,
+    develop: Option<Develop>,
+    domain_name: Option<Hostname>,
+    extends: Option<Extends>,
+    external_links: IndexSet<Link>,
+    isolation: Option<String>,
+    links: IndexSet<Link>,
+    logging_extensions: Extensions,
+    memswap_limit: Option<Limit<ByteValue>>,
+    profiles: IndexSet<Identifier>,
+    scale: Option<u64>,
+    volumes_from: IndexSet<VolumesFrom>,
+    extensions: Extensions,
+}
+
+impl Unsupported {
+    /// Ensure that all unsupported fields are [`None`] or empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a field is not empty.
+    pub fn ensure_empty(&self) -> color_eyre::Result<()> {
+        let Self {
+            attach,
+            build,
+            cpu_count,
+            cpu_percent,
+            configs,
+            credential_spec,
+            deploy,
+            develop,
+            domain_name,
+            extends,
+            external_links,
+            isolation,
+            links,
+            logging_extensions,
+            memswap_limit,
+            profiles,
+            scale,
+            volumes_from,
+            extensions,
+        } = self;
+
+        let unsupported_options = [
+            // `attach` default is `true`.
+            ("attach", *attach),
+            ("build", build.is_none()),
+            ("cpu_count", cpu_count.is_none()),
+            ("cpu_percent", cpu_percent.is_none()),
+            ("configs", configs.is_empty()),
+            ("credential_spec", credential_spec.is_none()),
+            ("deploy", deploy.is_none()),
+            ("develop", develop.is_none()),
+            ("domain_name", domain_name.is_none()),
+            ("extends", extends.is_none()),
+            ("external_links", external_links.is_empty()),
+            ("isolation", isolation.is_none()),
+            ("links", links.is_empty()),
+            ("memswap_limit", memswap_limit.is_none()),
+            ("profiles", profiles.is_empty()),
+            ("scale", scale.is_none()),
+            ("volumes_from", volumes_from.is_empty()),
+        ];
+
+        for (option, not_present) in unsupported_options {
+            ensure!(not_present, "`{option}` is not supported");
+        }
+
+        ensure!(
+            logging_extensions.is_empty() && extensions.is_empty(),
+            "compose extensions are not supported"
+        );
+
+        Ok(())
+    }
+}
+
+/// Fields taken from a [`compose_spec::Service`] for constructing a [`super::QuadletOptions`].
+pub struct Quadlet {
+    pub cap_add: IndexSet<String>,
+    pub cap_drop: IndexSet<String>,
+    pub container_name: Option<Identifier>,
+    pub devices: IndexSet<Device>,
+    pub dns: Option<ItemOrList<IpAddr>>,
+    pub dns_opt: IndexSet<String>,
+    pub dns_search: Option<ItemOrList<Hostname>>,
+    pub env_file: Option<EnvFile>,
+    pub environment: ListOrMap,
+    pub expose: IndexSet<Expose>,
+    pub annotations: ListOrMap,
+    pub healthcheck: Option<Healthcheck>,
+    pub hostname: Option<Hostname>,
+    pub init: bool,
+    pub labels: ListOrMap,
+    pub log_driver: Option<String>,
+    pub network_config: Option<NetworkConfig>,
+    pub pids_limit: Option<Limit<u32>>,
+    pub ports: Ports,
+    pub pull_policy: Option<PullPolicy>,
+    pub read_only: bool,
+    pub secrets: Vec<ShortOrLong<Identifier, ConfigOrSecret>>,
+    pub shm_size: Option<ByteValue>,
+    pub sysctls: ListOrMap,
+    pub tmpfs: Option<ItemOrList<PathBuf>>,
+    pub ulimits: Ulimits,
+    pub user: Option<UserOrGroup>,
+    pub userns_mode: Option<String>,
+    pub volumes: Volumes,
+    pub working_dir: Option<PathBuf>,
+}
+
+/// Fields taken from a [`compose_spec::Service`] for constructing a [`super::PodmanArgs`].
+#[allow(clippy::struct_excessive_bools)]
+pub struct PodmanArgs {
+    pub blkio_config: Option<BlkioConfig>,
+    pub cpu_shares: Option<u64>,
+    pub cpu_period: Option<Duration>,
+    pub cpu_quota: Option<Duration>,
+    pub cpu_rt_runtime: Option<Duration>,
+    pub cpu_rt_period: Option<Duration>,
+    pub cpus: Option<Cpus>,
+    pub cpuset: CpuSet,
+    pub cgroup: Option<Cgroup>,
+    pub cgroup_parent: Option<String>,
+    pub device_cgroup_rules: IndexSet<CgroupRule>,
+    pub entrypoint: Option<Command>,
+    pub extra_hosts: IndexMap<Hostname, IpAddr>,
+    pub group_add: IndexSet<UserOrGroup>,
+    pub ipc: Option<Ipc>,
+    pub uts: Option<Uts>,
+    pub log_options: IndexMap<MapKey, Option<StringOrNumber>>,
+    pub mac_address: Option<MacAddress>,
+    pub mem_limit: Option<ByteValue>,
+    pub mem_reservation: Option<ByteValue>,
+    pub mem_swappiness: Option<Percent>,
+    pub oom_kill_disable: bool,
+    pub oom_score_adj: Option<OomScoreAdj>,
+    pub pid: Option<String>,
+    pub platform: Option<Platform>,
+    pub privileged: bool,
+    pub stdin_open: bool,
+    pub stop_grace_period: Option<Duration>,
+    pub stop_signal: Option<String>,
+    pub tty: bool,
+}
+
+/// Fields taken from a [`compose_spec::Service`] for constructing the top-level fields in
+/// [`super::Container`].
+pub struct Container {
+    pub command: Option<Command>,
+    pub image: Option<Image>,
+    pub security_opt: IndexSet<String>,
+}

--- a/src/cli/container/compose.rs
+++ b/src/cli/container/compose.rs
@@ -1,14 +1,14 @@
 //! Types for splitting up a [`compose_spec::Service`] into parts and constructing a
 //! [`Container`](super::Container).
 
-use std::{net::IpAddr, path::PathBuf, time::Duration};
+use std::{net::IpAddr, time::Duration};
 
 use color_eyre::eyre::ensure;
 use compose_spec::{
     service::{
-        build::Context, device::CgroupRule, BlkioConfig, Build, ByteValue, Cgroup, Command,
-        ConfigOrSecret, CpuSet, Cpus, CredentialSpec, Deploy, Develop, Device, EnvFile, Expose,
-        Extends, Healthcheck, Hostname, Image, Ipc, Limit, Link, Logging, MacAddress,
+        build::Context, device::CgroupRule, AbsolutePath, BlkioConfig, Build, ByteValue, Cgroup,
+        Command, ConfigOrSecret, CpuSet, Cpus, CredentialSpec, Deploy, Develop, Device, EnvFile,
+        Expose, Extends, Healthcheck, Hostname, Image, Ipc, Limit, Link, Logging, MacAddress,
         NetworkConfig, OomScoreAdj, Percent, Platform, Ports, PullPolicy, Ulimits, UserOrGroup,
         Uts, Volumes, VolumesFrom,
     },
@@ -331,12 +331,12 @@ pub struct Quadlet {
     pub secrets: Vec<ShortOrLong<Identifier, ConfigOrSecret>>,
     pub shm_size: Option<ByteValue>,
     pub sysctls: ListOrMap,
-    pub tmpfs: Option<ItemOrList<PathBuf>>,
+    pub tmpfs: Option<ItemOrList<AbsolutePath>>,
     pub ulimits: Ulimits,
     pub user: Option<UserOrGroup>,
     pub userns_mode: Option<String>,
     pub volumes: Volumes,
-    pub working_dir: Option<PathBuf>,
+    pub working_dir: Option<AbsolutePath>,
 }
 
 /// Fields taken from a [`compose_spec::Service`] for constructing a [`super::PodmanArgs`].

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -12,6 +12,8 @@ use smart_default::SmartDefault;
 
 use crate::serde::skip_true;
 
+use super::compose;
+
 #[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
 #[derive(Args, Serialize, SmartDefault, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -403,6 +405,25 @@ impl Display for PodmanArgs {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let args = crate::serde::args::to_string(self).map_err(|_| fmt::Error)?;
         f.write_str(&args)
+    }
+}
+
+impl TryFrom<compose::PodmanArgs> for PodmanArgs {
+    type Error = color_eyre::Report;
+
+    fn try_from(value: compose::PodmanArgs) -> Result<Self, Self::Error> {
+        todo!();
+        // let log_opt = log_options
+        //     .into_iter()
+        //     .map(|(key, value)| {
+        //         let mut option = String::from(key);
+        //         if let Some(value) = value {
+        //             option.push('=');
+        //             option.push_str(&String::from(value));
+        //         }
+        //         option
+        //     })
+        //     .collect();
     }
 }
 

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -495,7 +495,9 @@ impl TryFrom<compose::PodmanArgs> for PodmanArgs {
             blkio_weight,
             blkio_weight_device: blkio_weight_device
                 .into_iter()
-                .map(|WeightDevice { path, weight }| format!("{}:{weight}", path.display()))
+                .map(|WeightDevice { path, weight }| {
+                    format!("{}:{weight}", path.as_path().display())
+                })
                 .collect(),
             cpu_shares,
             cpu_period: cpu_period.as_ref().map(Duration::as_micros),
@@ -561,13 +563,13 @@ impl TryFrom<compose::PodmanArgs> for PodmanArgs {
 /// Convert a [`BpsLimit`] from a [`compose_spec::Service`]'s [`BlkioConfig`] into a [`String`]
 /// suitable for the `device_read_bps` or `device_write_bps` field of [`PodmanArgs`].
 fn bps_limit_into_short(BpsLimit { path, rate }: BpsLimit) -> String {
-    format!("{}:{rate}", path.display())
+    format!("{}:{rate}", path.as_path().display())
 }
 
 /// Convert a [`IopsLimit`] from a [`compose_spec::Service`]'s [`BlkioConfig`] into a [`String`]
 /// suitable for the `device_read_iops` or `device_write_iops` field of [`PodmanArgs`].
 fn iops_limit_into_short(IopsLimit { path, rate }: IopsLimit) -> String {
-    format!("{}:{rate}", path.display())
+    format!("{}:{rate}", path.as_path().display())
 }
 
 /// Validate a compose [`Service`](compose_spec::Service) [`Ipc`] for use in [`PodmanArgs`].

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -393,6 +393,10 @@ pub struct PodmanArgs {
     #[arg(long)]
     umask: Option<String>,
 
+    /// Set the UTS namespace mode for the container
+    #[arg(long, value_name = "MODE")]
+    uts: Option<String>,
+
     /// Set variant to use instead of the default architecture variant of the container image
     #[arg(long)]
     variant: Option<String>,

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -46,8 +46,10 @@ pub struct PodmanArgs {
     blkio_weight: Option<Weight>,
 
     /// Block IO relative device weight
+    ///
+    /// Can be specified multiple times
     #[arg(long, value_name = "DEVICE:WEIGHT")]
-    blkio_weight_device: Option<String>,
+    blkio_weight_device: Vec<String>,
 
     /// Specify the cgroup file to write to and its value
     ///

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -406,6 +406,7 @@ impl Display for PodmanArgs {
     }
 }
 
+/*
 impl TryFrom<docker_compose_types::Service> for PodmanArgs {
     type Error = color_eyre::Report;
 
@@ -462,6 +463,7 @@ impl TryFrom<&mut docker_compose_types::Service> for PodmanArgs {
         })
     }
 }
+*/
 
 #[cfg(test)]
 mod tests {

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -649,7 +649,7 @@ impl TryFrom<compose::Quadlet> for QuadletOptions {
                 .map(ulimit_try_into_short)
                 .collect::<Result<_, _>>()
                 .wrap_err("error converting `ulimits`")?,
-            user: user.as_ref().map(ToString::to_string),
+            user: user.map(Into::into),
             userns,
             volume,
             workdir,

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -16,7 +16,6 @@ use color_eyre::{
 use smart_default::SmartDefault;
 
 use crate::{
-    cli::ComposeService,
     escape::command_join,
     quadlet::{
         container::{volume::Source, Device, Mount, PullPolicy, Rootfs, Volume},

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -12,7 +12,7 @@ use color_eyre::{
     owo_colors::OwoColorize,
     Section,
 };
-use docker_compose_types::{AdvancedVolumes, MapOrEmpty, Volumes};
+// use docker_compose_types::{AdvancedVolumes, MapOrEmpty, Volumes};
 use smart_default::SmartDefault;
 
 use crate::{
@@ -490,6 +490,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
     }
 }
 
+/*
 impl TryFrom<ComposeService> for QuadletOptions {
     type Error = color_eyre::Report;
 
@@ -644,6 +645,7 @@ impl TryFrom<&mut ComposeService> for QuadletOptions {
         })
     }
 }
+*/
 
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -655,6 +657,7 @@ struct Healthcheck {
     health_start_period: Option<String>,
 }
 
+/*
 impl From<docker_compose_types::Healthcheck> for Healthcheck {
     fn from(value: docker_compose_types::Healthcheck) -> Self {
         let docker_compose_types::Healthcheck {
@@ -906,6 +909,7 @@ fn map_networks(networks: docker_compose_types::Networks) -> Vec<String> {
             .collect(),
     }
 }
+*/
 
 #[cfg(test)]
 mod tests {

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -75,7 +75,7 @@ pub struct QuadletOptions {
     ///
     /// Can be specified multiple times
     #[arg(long, value_name = "IP_ADDRESS")]
-    dns: Vec<String>,
+    dns: Vec<IpAddr>,
 
     /// Set custom DNS options
     ///
@@ -163,7 +163,7 @@ pub struct QuadletOptions {
     ///
     /// Converts to "HealthRetries=RETRIES"
     #[arg(long, value_name = "RETRIES")]
-    health_retries: Option<u32>,
+    health_retries: Option<u64>,
 
     /// The initialization time needed for the container to bootstrap
     ///
@@ -520,426 +520,461 @@ impl From<QuadletOptions> for crate::quadlet::Container {
     }
 }
 
-/*
-impl TryFrom<ComposeService> for QuadletOptions {
+impl TryFrom<compose::Quadlet> for QuadletOptions {
     type Error = color_eyre::Report;
 
-    fn try_from(mut value: ComposeService) -> Result<Self, Self::Error> {
-        (&mut value).try_into()
-    }
-}
-
-impl TryFrom<&mut ComposeService> for QuadletOptions {
-    type Error = color_eyre::Report;
-
-    #[allow(clippy::too_many_lines)]
-    fn try_from(value: &mut ComposeService) -> Result<Self, Self::Error> {
-        let service = &mut value.service;
-
-        let device = mem::take(&mut service.devices)
-            .into_iter()
-            .map(|device| {
-                Device::from_str(&device).wrap_err_with(|| format!("invalid device: {device}"))
-            })
-            .collect::<Result<_, _>>()?;
-
+    fn try_from(
+        compose::Quadlet {
+            cap_add,
+            cap_drop,
+            container_name,
+            devices,
+            dns,
+            dns_opt,
+            dns_search,
+            env_file,
+            environment,
+            expose,
+            annotations,
+            healthcheck,
+            hostname,
+            init,
+            labels,
+            log_driver,
+            network_config,
+            pids_limit,
+            ports,
+            pull_policy,
+            read_only,
+            secrets,
+            shm_size,
+            sysctls,
+            tmpfs,
+            ulimits,
+            user,
+            userns_mode: userns,
+            volumes,
+            working_dir: workdir,
+        }: compose::Quadlet,
+    ) -> Result<Self, Self::Error> {
         let Healthcheck {
             health_cmd,
             health_interval,
             health_timeout,
             health_retries,
             health_start_period,
-        } = service
-            .healthcheck
-            .take()
-            .map(Healthcheck::from)
-            .unwrap_or_default();
+            health_startup_interval,
+        } = healthcheck
+            .unwrap_or_default()
+            .try_into()
+            .wrap_err("error converting `healthcheck`")?;
 
-        let publish =
-            ports_try_into_publish(mem::take(&mut service.ports)).wrap_err("invalid port")?;
-
-        let env = match mem::take(&mut service.environment) {
-            docker_compose_types::Environment::List(list) => list,
-            docker_compose_types::Environment::KvPair(map) => map
-                .into_iter()
-                .map(|(key, value)| {
-                    let value = value.as_ref().map(ToString::to_string).unwrap_or_default();
-                    format!("{key}={value}")
-                })
-                .collect(),
-        };
-
-        let network = service
-            .network_mode
-            .take()
-            .map(filter_network_mode)
-            .transpose()?
+        let mut tmpfs = tmpfs
             .into_iter()
-            .chain(map_networks(mem::take(&mut service.networks)))
+            .flat_map(ItemOrList::into_list)
+            .map(|tmpfs| tmpfs.display().to_string())
             .collect();
 
-        let label = match mem::take(&mut service.labels) {
-            docker_compose_types::Labels::List(vec) => vec,
-            docker_compose_types::Labels::Map(map) => map
-                .into_iter()
-                .map(|(key, value)| format!("{key}={value}"))
-                .collect(),
-        };
-
-        let sysctl = match mem::take(&mut service.sysctls) {
-            docker_compose_types::SysCtls::List(vec) => vec,
-            docker_compose_types::SysCtls::Map(map) => map
-                .into_iter()
-                .map(|(key, value)| {
-                    if let Some(value) = value {
-                        format!("{key}={value}")
-                    } else {
-                        key + "=null"
-                    }
-                })
-                .collect(),
-        };
-
-        let ulimit = mem::take(&mut service.ulimits)
-            .0
+        let volume = volumes
             .into_iter()
-            .map(|(kind, ulimit)| match ulimit {
-                docker_compose_types::Ulimit::Single(soft) => format!("{kind}={soft}"),
-                docker_compose_types::Ulimit::SoftHard { soft, hard } => {
-                    if hard == 0 {
-                        format!("{kind}={soft}")
-                    } else {
-                        format!("{kind}={soft}:{hard}")
-                    }
-                }
-            })
-            .collect();
-
-        let mut tmpfs = service
-            .tmpfs
-            .take()
-            .map(|tmpfs| match tmpfs {
-                docker_compose_types::Tmpfs::Simple(tmpfs) => vec![tmpfs],
-                docker_compose_types::Tmpfs::List(tmpfs) => tmpfs,
-            })
-            .unwrap_or_default();
-
-        let volume =
-            compose_volumes_try_into_volumes(value, &mut tmpfs).wrap_err("invalid volume")?;
-
-        let service = &mut value.service;
-
-        let env_file = service
-            .env_file
-            .take()
-            .map(|env_file| match env_file {
-                docker_compose_types::EnvFile::Simple(s) => vec![s.into()],
-                docker_compose_types::EnvFile::List(list) => {
-                    list.into_iter().map(Into::into).collect()
-                }
-            })
-            .unwrap_or_default();
+            .filter_map(|volume| volume_try_into_short(volume, &mut tmpfs).transpose())
+            .collect::<Result<_, _>>()
+            .wrap_err("error converting `volumes`")?;
 
         Ok(Self {
-            cap_add: mem::take(&mut service.cap_add),
-            name: service.container_name.take(),
-            dns: mem::take(&mut service.dns),
-            cap_drop: mem::take(&mut service.cap_drop),
-            publish,
-            env,
-            env_file,
-            network,
-            device,
-            label,
+            cap_add: cap_add.into_iter().collect(),
+            cap_drop: cap_drop.into_iter().collect(),
+            name: container_name.map(Into::into),
+            device: devices.into_iter().map(Into::into).collect(),
+            dns: dns.into_iter().flat_map(ItemOrList::into_list).collect(),
+            dns_option: dns_opt.into_iter().collect(),
+            dns_search: dns_search
+                .into_iter()
+                .flat_map(ItemOrList::into_list)
+                .map(Into::into)
+                .collect(),
+            env_file: env_file
+                .into_iter()
+                .flat_map(EnvFile::into_list)
+                .map(ShortOrLong::into_long)
+                .map(|env_file::Config { path, required }| {
+                    required
+                        .then_some(path)
+                        .ok_or_eyre("optional environment files are not supported")
+                })
+                .collect::<color_eyre::Result<_>>()
+                .wrap_err("error converting `env_file`")?,
+            env: environment.into_list().into_iter().collect(),
+            expose: expose.iter().map(ToString::to_string).collect(),
+            annotation: annotations.into_list().into_iter().collect(),
             health_cmd,
             health_interval,
+            health_timeout,
             health_retries,
             health_start_period,
-            health_timeout,
-            hostname: service.hostname.take(),
-            shm_size: service.shm_size.take(),
-            sysctl,
+            health_startup_interval,
+            hostname: hostname.map(Into::into),
+            init,
+            label: labels.into_list().into_iter().collect(),
+            log_driver,
+            network: network_config
+                .map(network_config_try_into_network_options)
+                .transpose()
+                .wrap_err("error converting network configuration")?
+                .unwrap_or_default(),
+            pids_limit,
+            publish: ports::into_short_iter(ports)
+                .map(|port| {
+                    port.as_ref().map(ToString::to_string).map_err(|port| {
+                        eyre!("could not convert port to short syntax, port = {port:#?}")
+                    })
+                })
+                .collect::<Result<_, _>>()
+                .wrap_err("error converting `ports`")?,
+            pull: pull_policy
+                .map(TryInto::try_into)
+                .transpose()
+                .wrap_err("error converting `pull_policy`")?,
+            read_only,
+            secret: secrets
+                .into_iter()
+                .map(secret_try_into_short)
+                .collect::<Result<_, _>>()
+                .wrap_err("error converting `secrets`")?,
+            shm_size: shm_size.as_ref().map(ToString::to_string),
+            sysctl: sysctls.into_list().into_iter().collect(),
             tmpfs,
-            ulimit,
-            user: service.user.take(),
-            userns: service.userns_mode.take(),
-            expose: mem::take(&mut service.expose),
-            log_driver: service
-                .logging
-                .as_mut()
-                .map(|logging| mem::take(&mut logging.driver)),
-            init: service.init,
+            ulimit: ulimits
+                .into_iter()
+                .map(ulimit_try_into_short)
+                .collect::<Result<_, _>>()
+                .wrap_err("error converting `ulimits`")?,
+            user: user.as_ref().map(ToString::to_string),
+            userns,
             volume,
-            workdir: service.working_dir.take().map(Into::into),
+            workdir,
             ..Self::default()
         })
     }
 }
-*/
 
+/// Healthcheck options used in [`QuadletOptions`].
+///
+/// Used for converting from [`compose_spec::service::Healthcheck`].
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone, PartialEq)]
 struct Healthcheck {
     health_cmd: Option<String>,
     health_interval: Option<String>,
     health_timeout: Option<String>,
-    health_retries: Option<u32>,
+    health_retries: Option<u64>,
     health_start_period: Option<String>,
+    health_startup_interval: Option<String>,
 }
 
-/*
-impl From<docker_compose_types::Healthcheck> for Healthcheck {
-    fn from(value: docker_compose_types::Healthcheck) -> Self {
-        let docker_compose_types::Healthcheck {
-            test,
-            interval,
-            timeout,
-            retries,
-            start_period,
-            mut disable,
-        } = value;
+impl TryFrom<service::Healthcheck> for Healthcheck {
+    type Error = color_eyre::Report;
 
-        let mut command = test.and_then(|test| match test {
-            docker_compose_types::HealthcheckTest::Single(s) => Some(s),
-            docker_compose_types::HealthcheckTest::Multiple(test) => {
-                #[allow(clippy::indexing_slicing)]
-                match test.first().map(String::as_str) {
-                    Some("NONE") => {
-                        disable = true;
-                        None
-                    }
-                    Some("CMD") => Some(format!("{:?}", &test[1..])),
-                    Some("CMD-SHELL") => Some(command_join(&test[1..])),
-                    _ => None,
-                }
+    fn try_from(value: service::Healthcheck) -> Result<Self, Self::Error> {
+        use service::healthcheck::{Command, Healthcheck, Test};
+
+        match value {
+            Healthcheck::Command(Command {
+                test,
+                interval,
+                timeout,
+                retries,
+                start_period,
+                start_interval,
+                extensions,
+            }) => {
+                ensure!(
+                    extensions.is_empty(),
+                    "compose extensions are not supported"
+                );
+                Ok(Self {
+                    health_cmd: test
+                        .map(|test| match test {
+                            Test::Command(command) => serde_json::to_string(&command)
+                                .wrap_err("error serializing healthcheck test command as JSON"),
+                            Test::ShellCommand(command) => Ok(command),
+                        })
+                        .transpose()?,
+                    health_interval: interval.map(duration::to_string),
+                    health_timeout: timeout.map(duration::to_string),
+                    health_retries: retries,
+                    health_start_period: start_period.map(duration::to_string),
+                    health_startup_interval: start_interval.map(duration::to_string),
+                })
             }
-        });
-
-        if disable {
-            command = Some(String::from("none"));
-        }
-
-        let retries = (retries > 0).then(|| u32::try_from(retries).unwrap_or_default());
-        Self {
-            health_cmd: command,
-            health_interval: interval,
-            health_timeout: timeout,
-            health_retries: retries,
-            health_start_period: start_period,
+            Healthcheck::Disable => Ok(Self {
+                health_cmd: Some("none".to_owned()),
+                ..Self::default()
+            }),
         }
     }
 }
 
-fn ports_try_into_publish(ports: docker_compose_types::Ports) -> color_eyre::Result<Vec<String>> {
-    match ports {
-        docker_compose_types::Ports::Short(ports) => Ok(ports),
-        docker_compose_types::Ports::Long(ports) => ports
+/// Attempt to convert a volume from a [`compose_spec::Service`] into a form suitable for
+/// `podman run --volume` or `podman run --tmpfs`.
+///
+/// [`Tmpfs`] volumes will be converted, added to `tmpfs`, and [`None`] is returned.
+///
+/// # Errors
+///
+/// Returns an error if the volume is not compatible with `podman run --volume` or
+/// `podman run --tmpfs`.
+fn volume_try_into_short(
+    volume: ShortOrLong<ShortVolume, volumes::Mount>,
+    tmpfs: &mut Vec<String>,
+) -> color_eyre::Result<Option<Volume>> {
+    match volume {
+        ShortOrLong::Short(volume) => Ok(Some(volume.into())),
+        ShortOrLong::Long(volumes::Mount::Volume(mount)) => mount.try_into().map(Some),
+        ShortOrLong::Long(volumes::Mount::Bind(mount)) => mount.try_into().map(Some),
+        ShortOrLong::Long(volumes::Mount::Tmpfs(mount)) => {
+            let mount = tmpfs_try_into_short(mount).wrap_err("error converting tmpfs volume")?;
+            tmpfs.push(mount);
+            Ok(None)
+        }
+        ShortOrLong::Long(volumes::Mount::NamedPipe(_)) => {
+            Err(eyre!("`npipe` type volumes are not supported"))
+        }
+        ShortOrLong::Long(volumes::Mount::Cluster(_)) => {
+            Err(eyre!("`cluster` type volumes are not supported"))
+        }
+    }
+}
+
+/// Attempt to convert a [`Tmpfs`] volume from a [`compose_spec::Service`] into a form suitable for
+/// `podman run --tmpfs`.
+///
+/// # Errors
+///
+/// Returns an error if the [`Tmpfs`] is not compatible with `podman run --tmpfs`.
+fn tmpfs_try_into_short(
+    Tmpfs {
+        tmpfs,
+        common:
+            Common {
+                target,
+                read_only,
+                consistency,
+                extensions,
+            },
+    }: Tmpfs,
+) -> color_eyre::Result<String> {
+    ensure!(
+        consistency.is_none(),
+        "`consistency` volume option is not supported"
+    );
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let TmpfsOptions {
+        size,
+        mode,
+        extensions,
+    } = tmpfs.unwrap_or_default();
+
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let mut tmpfs = target.as_path().display().to_string();
+
+    let options = read_only
+        .then(|| "ro".to_owned())
+        .into_iter()
+        .chain(size.map(|size| format!("size={size}")))
+        .chain(mode.map(|mode| format!("mode={mode:o}")));
+
+    let mut first = true;
+    for option in options {
+        let separator = if first {
+            first = false;
+            ':'
+        } else {
+            ','
+        };
+        tmpfs.push(separator);
+        tmpfs.push_str(&option);
+    }
+
+    Ok(tmpfs)
+}
+
+/// Attempt to convert a compose service [`NetworkConfig`] into network options for the `network`
+/// field of [`QuadletOptions`].
+///
+/// # Errors
+///
+/// Returns an error if an option is not supported by `podman run --network`.
+fn network_config_try_into_network_options(
+    network_config: NetworkConfig,
+) -> color_eyre::Result<Vec<String>> {
+    match network_config {
+        NetworkConfig::NetworkMode(network_mode) => {
+            validate_network_mode(network_mode).map(|network_mode| vec![network_mode])
+        }
+        NetworkConfig::Networks(networks) => networks
+            .into_long()
             .into_iter()
-            .map(|port| {
-                let docker_compose_types::Port {
-                    target,
-                    host_ip,
-                    published,
-                    protocol,
-                    mode,
-                } = port;
-                if let Some(mode) = mode {
-                    eyre::ensure!(mode == "host", "unsupported port mode: {mode}");
+            .map(|(network, options)| {
+                let mut network = String::from(network);
+                if let Some(options) = options {
+                    let options = network_options(options).wrap_err_with(|| {
+                        format!("error converting `{network}` network options")
+                    })?;
+                    network.push(':');
+                    network.push_str(&options);
                 }
-
-                let host_ip = host_ip.map(|host_ip| host_ip + ":").unwrap_or_default();
-
-                let host_port = published
-                        .map(|port| match port {
-                            docker_compose_types::PublishedPort::Single(port) => port.to_string(),
-                            docker_compose_types::PublishedPort::Range(range) => range,
-                        } + ":")
-                        .unwrap_or_default();
-
-                let protocol = protocol
-                    .map(|protocol| format!("/{protocol}"))
-                    .unwrap_or_default();
-
-                Ok(format!("{host_ip}{host_port}{target}{protocol}"))
+                Ok(network)
             })
             .collect(),
     }
 }
 
-/// Takes the [`Volumes`] from a service and converts them to a quadlet container [`Volume`],
-/// or adds them to `tmpfs` if a tmpfs mount.
+/// Validate a compose service [`NetworkMode`] for use in [`QuadletOptions`].
 ///
 /// # Errors
 ///
-/// Returns an error if a volume cannot be parsed.
-fn compose_volumes_try_into_volumes(
-    service: &mut ComposeService,
-    tmpfs: &mut Vec<String>,
-) -> color_eyre::Result<Vec<Volume>> {
-    mem::take(&mut service.service.volumes)
-        .into_iter()
-        .try_fold(Vec::new(), |mut volumes, volume| {
-            let mut volume = match volume {
-                Volumes::Simple(volume) => volume
-                    .parse()
-                    .wrap_err_with(|| format!("error parsing `{volume}` as volume"))?,
-                Volumes::Advanced(volume) => {
-                    if let Some(volume) = advanced_volume_try_into_volume(volume, tmpfs)? {
-                        volume
-                    } else {
-                        return Ok(volumes);
-                    }
-                }
-            };
-
-            if let Some(Source::NamedVolume(volume)) = &mut volume.source {
-                if service.volume_has_options(volume) {
-                    volume.push_str(".volume");
-                }
-            }
-
-            volumes.push(volume);
-            Ok(volumes)
-        })
-}
-
-/// Convert [`AdvancedVolumes`] into [`Volume`].
-///
-/// Returns [`None`] if volume is a tmpfs mount which is added to `tmpfs`.
-///
-/// # Errors
-///
-/// Returns an error if a volume is specified without a source or the bind propagation value
-/// could not be parsed.
-fn advanced_volume_try_into_volume(
-    AdvancedVolumes {
-        source,
-        target,
-        _type: kind,
-        read_only,
-        bind,
-        volume: volume_options,
-        tmpfs: tmpfs_settings,
-    }: AdvancedVolumes,
-    tmpfs: &mut Vec<String>,
-) -> color_eyre::Result<Option<Volume>> {
-    match kind.as_str() {
-        "bind" | "volume" => {
-            let source = source.ok_or_eyre("volume without a source")?;
-            let mut volume = Volume::new(target.into());
-            volume.source = Some(source.into());
-            volume.options.read_only = read_only;
-
-            if let Some(bind) = &bind {
-                volume.options.bind_propagation = bind.propagation.parse().wrap_err_with(|| {
-                    format!(
-                        "error parsing `{}` as bind propagation value",
-                        bind.propagation
-                    )
-                })?;
-            }
-
-            if volume_options.is_some_and(|options| options.nocopy) {
-                volume.options.no_copy = true;
-            }
-
-            Ok(Some(volume))
-        }
-        "tmpfs" => {
-            let mut options = String::new();
-
-            if read_only {
-                options.push_str("ro");
-            }
-
-            if let Some(docker_compose_types::TmpfsSettings { size }) = tmpfs_settings {
-                if read_only {
-                    options.push(',');
-                }
-                write!(options, "size={size}").expect("writing to String never fails");
-            }
-
-            let tmpfs_volume = if options.is_empty() {
-                target
+/// Returns an error if the given `network_mode` is not supported by `podman run --network`.
+fn validate_network_mode(network_mode: NetworkMode) -> color_eyre::Result<String> {
+    match network_mode {
+        NetworkMode::None | NetworkMode::Host => Ok(network_mode.to_string()),
+        NetworkMode::Service(_) => Err(eyre!("network_mode `service:` is not supported")
+            .suggestion("try using the `container:` network_mode instead")),
+        NetworkMode::Other(s) => {
+            if s.starts_with("bridge")
+                || s.starts_with("container")
+                || s.starts_with("ns:")
+                || s == "private"
+                || s.starts_with("slirp4netns")
+                || s.starts_with("pasta")
+            {
+                Ok(s)
             } else {
-                format!("{target}:{options}")
-            };
-
-            tmpfs.push(tmpfs_volume);
-            Ok(None)
+                Err(eyre!("network_mode `{s}` is not supported by podman"))
+            }
         }
-        _ => eyre::bail!("unsupported volume type: {kind}"),
-    }
-}
-
-/// Filters out unsupported compose service `network_mode`s.
-///
-/// # Errors
-///
-/// Returns an error if the given `mode` is not supported by `podman run --network`.
-fn filter_network_mode(mode: String) -> color_eyre::Result<String> {
-    match mode.as_str() {
-        "host" | "none" | "private" => Ok(mode),
-        s if s.starts_with("bridge")
-            || s.starts_with("container")
-            || s.starts_with("slirp4netns")
-            || s.starts_with("pasta") =>
-        {
-            Ok(mode)
-        }
-        s if s.starts_with("service") => Err(eyre::eyre!(
-            "network_mode `service:` is not supported by podman"
-        ))
-        .suggestion("try using the `container:` network_mode instead"),
-        _ => Err(eyre::eyre!("network_mode `{mode}` is not supported")),
     }
     .with_suggestion(|| {
         format!(
-            "see the --network section of the {} documentation for supported values: \
+            "see the --network section of the {}(1) documentation for supported values: \
                 https://docs.podman.io/en/stable/markdown/podman-run.1.html#network-mode-net",
-            "podman-run(1)".bold()
+            "podman-run".bold()
         )
     })
 }
 
-fn map_networks(networks: docker_compose_types::Networks) -> Vec<String> {
-    match networks {
-        docker_compose_types::Networks::Simple(networks) => networks
-            .into_iter()
-            .map(|network| network + ".network")
-            .collect(),
-        docker_compose_types::Networks::Advanced(networks) => networks
-            .0
-            .into_iter()
-            .map(|(network, settings)| {
-                let options =
-                    if let MapOrEmpty::Map(docker_compose_types::AdvancedNetworkSettings {
-                        ipv4_address,
-                        ipv6_address,
-                        aliases,
-                    }) = settings
-                    {
-                        let mut options = Vec::new();
-                        for ip in ipv4_address.into_iter().chain(ipv6_address) {
-                            options.push(format!("ip={ip}"));
-                        }
-                        for alias in aliases {
-                            options.push(format!("alias={alias}"));
-                        }
-                        if options.is_empty() {
-                            String::new()
-                        } else {
-                            format!(":{}", options.join(","))
-                        }
-                    } else {
-                        String::new()
-                    };
-                format!("{network}.network{options}")
-            })
-            .collect(),
+/// Convert compose service [`Network`] options into a comma (,) separated list of key value pairs.
+///
+/// # Errors
+///
+/// Returns an error if an option not supported by `podman run --network` is used.
+fn network_options(
+    Network {
+        aliases,
+        ipv4_address,
+        ipv6_address,
+        link_local_ips,
+        mac_address,
+        priority,
+        extensions,
+    }: Network,
+) -> color_eyre::Result<String> {
+    ensure!(
+        link_local_ips.is_empty(),
+        "network `link_local_ips` option is not supported"
+    );
+    ensure!(
+        priority.is_none(),
+        "network `priority` option is not supported"
+    );
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let ip_addrs = ipv4_address
+        .map(IpAddr::from)
+        .into_iter()
+        .chain(ipv6_address.map(IpAddr::from))
+        .map(|ip_addr| format!("ip={ip_addr}"));
+
+    let options: Vec<_> = aliases
+        .into_iter()
+        .map(|alias| format!("alias={alias}"))
+        .chain(ip_addrs)
+        .chain(mac_address.map(|mac| format!("mac={mac}")))
+        .collect();
+
+    Ok(options.join(","))
+}
+
+/// Attempt to convert a secret from a [`compose_spec::Service`] into a form suitable for
+/// `podman run --secret`.
+///
+/// # Errors
+///
+/// Returns an error if the secret has extensions.
+fn secret_try_into_short(
+    secret: ShortOrLong<Identifier, ConfigOrSecret>,
+) -> color_eyre::Result<String> {
+    match secret {
+        ShortOrLong::Short(secret) => Ok(secret.into()),
+        ShortOrLong::Long(ConfigOrSecret {
+            source,
+            target,
+            uid,
+            gid,
+            mode,
+            extensions,
+        }) => {
+            ensure!(
+                extensions.is_empty(),
+                "compose extensions are not supported"
+            );
+
+            Ok(iter::once(source.into())
+                .chain(target.map(|target| format!("target={}", target.display())))
+                .chain(uid.map(|uid| format!("uid={uid}")))
+                .chain(gid.map(|gid| format!("gid={gid}")))
+                .chain(mode.map(|mode| format!("mode={mode:o}")))
+                .collect::<Vec<_>>()
+                .join(","))
+        }
     }
 }
-*/
+
+/// Attempt to convert a ulimit from a [`compose_spec::Service`] into a form suitable for
+/// `podman run --ulimit`.
+///
+/// # Errors
+///
+/// Returns an error if the [`Ulimit`] has extensions.
+fn ulimit_try_into_short(
+    (resource, ulimit): (service::Resource, ShortOrLong<u64, Ulimit>),
+) -> color_eyre::Result<String> {
+    match ulimit {
+        ShortOrLong::Short(ulimit) => Ok(format!("{resource}={ulimit}")),
+        ShortOrLong::Long(Ulimit {
+            soft,
+            hard,
+            extensions,
+        }) => {
+            ensure!(
+                extensions.is_empty(),
+                "compose extensions are not supported"
+            );
+            Ok(format!("{resource}={soft}:{hard}"))
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -554,7 +554,7 @@ impl TryFrom<compose::Quadlet> for QuadletOptions {
             user,
             userns_mode: userns,
             volumes,
-            working_dir: workdir,
+            working_dir,
         }: compose::Quadlet,
     ) -> Result<Self, Self::Error> {
         let Healthcheck {
@@ -572,7 +572,7 @@ impl TryFrom<compose::Quadlet> for QuadletOptions {
         let mut tmpfs = tmpfs
             .into_iter()
             .flat_map(ItemOrList::into_list)
-            .map(|tmpfs| tmpfs.display().to_string())
+            .map(|tmpfs| tmpfs.as_path().display().to_string())
             .collect();
 
         let volume = volumes
@@ -652,7 +652,7 @@ impl TryFrom<compose::Quadlet> for QuadletOptions {
             user: user.map(Into::into),
             userns,
             volume,
-            workdir,
+            workdir: working_dir.map(Into::into),
             ..Self::default()
         })
     }

--- a/src/cli/k8s.rs
+++ b/src/cli/k8s.rs
@@ -1,977 +1,118 @@
-use std::collections::BTreeMap;
+//! Kubernetes YAML [`File`] for converting a [`Compose`] file into a [`Pod`] and
+//! [`PersistentVolumeClaim`]s.
 
-use color_eyre::{
-    eyre::{self, Context, OptionExt},
-    Help,
-};
-/*
-use docker_compose_types::{
-    AdvancedVolumes, Compose, ComposeVolume, Entrypoint, Environment, Healthcheck, HealthcheckTest,
-    Labels, Ports, PublishedPort, Service, SingleValue, Tmpfs, Ulimit, Ulimits,
-    Volumes as ComposeVolumes,
-};
-*/
-use indexmap::IndexMap;
+mod service;
+mod volume;
+
+use std::fmt::{self, Display, Formatter};
+
+use color_eyre::eyre::{ensure, OptionExt, WrapErr};
+use compose_spec::{Compose, Resource};
 use k8s_openapi::{
-    api::core::v1::{
-        Capabilities, Container, ContainerPort, EmptyDirVolumeSource, EnvVar, ExecAction,
-        HostPathVolumeSource, PersistentVolumeClaim, PersistentVolumeClaimVolumeSource, Pod,
-        PodSpec, Probe, ResourceRequirements, SELinuxOptions, SecurityContext, Volume, VolumeMount,
-    },
-    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
+    api::core::v1::{PersistentVolumeClaim, Pod, PodSpec},
+    apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
 
-use super::{
-    compose,
-    container::security_opt::{LabelOpt, SecurityOpt},
-};
+use self::service::Service;
 
-/*
-pub fn compose_try_into_pod(
-    mut compose: Compose,
-    name: String,
-) -> color_eyre::Result<(Pod, Vec<PersistentVolumeClaim>)> {
-    let mut volumes = Vec::new();
+/// A Kubernetes YAML file representing a [`Pod`] and optional [`PersistentVolumeClaim`]s.
+///
+/// Created by converting from a [`Compose`] file.
+#[derive(Debug)]
+pub struct File {
+    /// The name of the file, without the extension.
+    pub name: String,
 
-    let containers = compose::services(&mut compose)
-        .map(|result| {
-            result.and_then(|(name, service)| {
-                let (container, container_volumes) =
-                    service_try_into_container(name.clone(), service).wrap_err_with(|| {
-                        format!("could not convert service `{name}` into k8s container spec")
-                    })?;
-                volumes.extend(container_volumes);
-                Ok(container)
-            })
-        })
-        .collect::<color_eyre::Result<_>>()?;
+    /// The Kubernetes [`Pod`].
+    pub pod: Pod,
 
-    let spec = PodSpec {
-        containers,
-        volumes: volumes.filter_empty(),
-        ..PodSpec::default()
-    };
-
-    let pod = Pod {
-        metadata: ObjectMeta {
-            name: Some(name),
-            ..ObjectMeta::default()
-        },
-        spec: Some(spec),
-        status: None,
-    };
-
-    let persistent_volume_claims = compose
-        .volumes
-        .0
-        .into_iter()
-        .filter_map(|(name, volume)| {
-            Option::<ComposeVolume>::from(volume).map(|volume| {
-                compose_volume_try_into_persistent_volume_claim(volume, name.clone()).wrap_err_with(
-                    || {
-                        format!(
-                            "could not convert volume `{name}` into \
-                                k8s persistent volume claim spec"
-                        )
-                    },
-                )
-            })
-        })
-        .collect::<color_eyre::Result<_>>()?;
-
-    Ok((pod, persistent_volume_claims))
+    /// Optional Kubernetes [`PersistentVolumeClaim`]s.
+    ///
+    /// Needed if a [`compose_spec::Volume`] has additional options set.
+    pub persistent_volume_claims: Vec<PersistentVolumeClaim>,
 }
 
-fn service_try_into_container(
-    name: String,
-    service: Service,
-) -> color_eyre::Result<(Container, Vec<Volume>)> {
-    service_check_unsupported(&service)?;
+impl TryFrom<Compose> for File {
+    type Error = color_eyre::Report;
 
-    let name = service.container_name.unwrap_or(name);
-
-    let liveness_probe = service
-        .healthcheck
-        .filter(|healthcheck| !healthcheck_is_disable(healthcheck))
-        .map(healthcheck_try_into_probe)
-        .transpose()
-        .wrap_err("could not convert healthcheck into k8s liveness probe")?;
-
-    let capabilities = Capabilities {
-        add: service.cap_add.filter_empty(),
-        drop: None,
-    };
-    let se_linux_options = security_opts_try_into_se_linux_options(service.security_opt)
-        .wrap_err("unsupported security option")?;
-    let security_context = SecurityContext {
-        privileged: service.privileged.then_some(true),
-        capabilities: capabilities.filter_default(),
-        se_linux_options: se_linux_options.filter_default(),
-        run_as_user: service
-            .user
-            .map(|user| user.parse())
-            .transpose()
-            .wrap_err("user must be specified as a UID")?,
-        ..SecurityContext::default()
-    };
-
-    let ports = ports_try_into_container_ports(service.ports).wrap_err("could not parse ports")?;
-
-    let env = environment_into_env_vars(service.environment);
-
-    let (volume_mounts, volumes): (Vec<_>, _) = service
-        .tmpfs
-        .into_iter()
-        .flat_map(|tmpfs| match tmpfs {
-            Tmpfs::Simple(tmpfs) => vec![parse_tmpfs_volume_mount(&tmpfs, &name)],
-            Tmpfs::List(tmpfs) => tmpfs
-                .into_iter()
-                .map(|tmpfs| parse_tmpfs_volume_mount(&tmpfs, &name))
-                .collect(),
-        })
-        .chain(
-            compose_volumes_try_into_volume_mounts(service.volumes, &name)
-                .wrap_err("could not parse volumes")?,
-        )
-        .unzip();
-
-    let args = service
-        .command
-        .map(compose::command_try_into_vec)
-        .transpose()?;
-
-    let command = service.entrypoint.map(|entrypoint| match entrypoint {
-        Entrypoint::Simple(entrypoint) => vec![entrypoint],
-        Entrypoint::List(entrypoint) => entrypoint,
-    });
-
-    let container = Container {
-        name,
-        image: service.image,
-        command,
-        args,
-        liveness_probe,
-        security_context: security_context.filter_default(),
-        ports: ports.filter_empty(),
-        env: env.filter_empty(),
-        resources: ulimits_into_resources(service.ulimits),
-        working_dir: service.working_dir,
-        stdin: service.stdin_open.then_some(true),
-        tty: service.tty.then_some(true),
-        volume_mounts: volume_mounts.filter_empty(),
-        ..Container::default()
-    };
-
-    Ok((container, volumes))
-}
-
-fn service_check_unsupported(service: &Service) -> color_eyre::Result<()> {
-    let unsupported_options = [
-        ("hostname", service.hostname.is_none()),
-        ("deploy", service.deploy.is_none()),
-        ("build", service.build_.is_none()),
-        ("depends_on", service.depends_on.is_empty()),
-        ("env_file", service.env_file.is_none()),
-        ("profiles", service.profiles.is_empty()),
-        ("links", service.links.is_empty()),
-        ("net", service.net.is_none()),
-        ("stop_signal", service.stop_signal.is_none()),
-        ("expose", service.expose.is_empty()),
-        ("volumes_from", service.volumes_from.is_empty()),
-        ("extends", service.extends.is_empty()),
-        ("scale", service.scale == 0),
-        ("init", !service.init),
-        ("shm_size", service.shm_size.is_none()),
-        ("sysctls", service.sysctls.is_empty()),
-    ];
-    for (option, not_present) in unsupported_options {
-        eyre::ensure!(not_present, "`{option}` is not supported for pods");
-    }
-
-    let unsupported_container_options = [
-        ("pid", service.pid.is_none()),
-        ("network_mode", service.network_mode.is_none()),
-        ("restart", service.restart.is_none()),
-        ("labels", service.labels.is_empty()),
-        ("networks", service.networks.is_empty()),
-        ("stop_grace_period", service.stop_grace_period.is_none()),
-        ("dns", service.dns.is_empty()),
-        ("ipc", service.ipc.is_none()),
-        ("logging", service.logging.is_none()),
-        ("extra_hosts", service.extra_hosts.is_empty()),
-    ];
-    for (option, not_present) in unsupported_container_options {
-        eyre::ensure!(
-            not_present,
-            "pods do not support per container `{option}` options, \
-                try setting the pod option instead",
+    fn try_from(
+        Compose {
+            version: _,
+            name,
+            include,
+            services,
+            networks,
+            volumes,
+            configs,
+            secrets,
+            extensions,
+        }: Compose,
+    ) -> Result<Self, Self::Error> {
+        ensure!(include.is_empty(), "`include` is not supported");
+        ensure!(networks.is_empty(), "`networks` is not supported");
+        ensure!(configs.is_empty(), "`configs` is not supported");
+        ensure!(secrets.is_empty(), "`secrets` is not supported");
+        ensure!(
+            extensions.is_empty(),
+            "compose extensions are not supported"
         );
-    }
 
-    eyre::ensure!(
-        service.devices.is_empty(),
-        "pods do not directly support devices, try using a bind mount instead"
-    );
+        let name = name.map(String::from).ok_or_eyre("`name` is required")?;
 
-    eyre::ensure!(
-        service.extensions.is_empty(),
-        "podman does not support docker extensions"
-    );
-
-    Ok(())
-}
-
-fn healthcheck_is_disable(healthcheck: &Healthcheck) -> bool {
-    healthcheck.disable
-        || healthcheck
-            .test
-            .as_ref()
-            .map(|test| match test {
-                HealthcheckTest::Single(_) => false,
-                HealthcheckTest::Multiple(test) => test == &["NONE"],
-            })
-            .unwrap_or_default()
-}
-
-fn healthcheck_try_into_probe(healthcheck: Healthcheck) -> color_eyre::Result<Probe> {
-    let Healthcheck {
-        test,
-        interval,
-        timeout,
-        retries,
-        start_period,
-        disable: _,
-    } = healthcheck;
-
-    let exec = test
-        .map(|test| {
-            match test {
-                HealthcheckTest::Single(_) => None,
-                HealthcheckTest::Multiple(mut test) => match test.first().map(String::as_str) {
-                    Some("CMD") => {
-                        test.remove(0); // can't panic, there is at least one element ("CMD")
-                        Some(ExecAction {
-                            command: Some(test),
-                        })
-                    }
-                    _ => None,
-                },
-            }
-            .ok_or_eyre("healthcheck implicitly using a shell is not supported for pods")
-            .suggestion(r#"change healthcheck test to '["CMD", "/bin/sh", "-c", ...]'"#)
-        })
-        .transpose()?;
-
-    let period_seconds = interval
-        .map(|interval| parse_seconds(&interval))
-        .transpose()
-        .wrap_err("could not parse `interval`")?;
-
-    let timeout_seconds = timeout
-        .map(|timeout| parse_seconds(&timeout))
-        .transpose()
-        .wrap_err("could not parse `timeout`")?;
-
-    let failure_threshold = (retries != 0)
-        .then(|| retries.try_into())
-        .transpose()
-        .wrap_err_with(|| format!("`{retries}` retries is too large"))?;
-
-    let initial_delay_seconds = start_period
-        .map(|start_period| parse_seconds(&start_period))
-        .transpose()
-        .wrap_err("could not parse `start_period`")?;
-
-    Ok(Probe {
-        exec,
-        failure_threshold,
-        initial_delay_seconds,
-        period_seconds,
-        timeout_seconds,
-        ..Probe::default()
-    })
-}
-*/
-
-fn parse_seconds(duration: &str) -> color_eyre::Result<i32> {
-    duration_str::parse(duration)
-        .wrap_err_with(|| format!("could not parse `{duration}` as a valid duration"))
-        .and_then(|period| {
-            let seconds = period.as_secs();
-            seconds
-                .try_into()
-                .wrap_err_with(|| format!("`{seconds}` seconds is too large"))
-        })
-}
-
-fn security_opts_try_into_se_linux_options(
-    security_opts: Vec<String>,
-) -> color_eyre::Result<SELinuxOptions> {
-    security_opts.into_iter().try_fold(
-        SELinuxOptions::default(),
-        |mut se_linux_options, security_opt| {
-            let security_opt = if security_opt == "no-new-privileges:true" {
-                SecurityOpt::NoNewPrivileges
-            } else if security_opt == "no-new-privileges:false" {
-                return Ok(se_linux_options);
-            } else {
-                security_opt.replacen(':', "=", 1).parse()?
-            };
-
-            match security_opt {
-                SecurityOpt::Apparmor(_) => Err(eyre::eyre!(
-                    "`apparmor` security_opt is not supported for pods"
-                )),
-                SecurityOpt::Label(label_opt) => match label_opt {
-                    LabelOpt::User(user) => {
-                        se_linux_options.user = Some(user);
-                        Ok(se_linux_options)
-                    }
-                    LabelOpt::Role(role) => {
-                        se_linux_options.role = Some(role);
-                        Ok(se_linux_options)
-                    }
-                    LabelOpt::Type(kind) => {
-                        se_linux_options.type_ = Some(kind);
-                        Ok(se_linux_options)
-                    }
-                    LabelOpt::Level(level) => {
-                        se_linux_options.level = Some(level);
-                        Ok(se_linux_options)
-                    }
-                    LabelOpt::Filetype(_) => Err(eyre::eyre!(
-                        "`label:filetype` security_opt is not supported for pods"
-                    )),
-                    LabelOpt::Disable => Err(eyre::eyre!(
-                        "`label:disable` security_opt is not supported for pods"
-                    )),
-                    LabelOpt::Nested => Err(eyre::eyre!(
-                        "`label:nested` security_opt is not supported for pods"
-                    )),
-                },
-                SecurityOpt::Mask(_) => {
-                    Err(eyre::eyre!("`mask` security_opt is not supported for pods"))
-                }
-                SecurityOpt::NoNewPrivileges => Err(eyre::eyre!(
-                    "`no-new-privileges` security_opt is not supported for pods"
-                )),
-                SecurityOpt::Seccomp(_) => Err(eyre::eyre!(
-                    "`seccomp` security_opt is not supported for pods"
-                )),
-                SecurityOpt::ProcOpts(_) => Err(eyre::eyre!(
-                    "`proc-opts` security_opt is not supported for pods"
-                )),
-                SecurityOpt::Unmask(_) => Err(eyre::eyre!(
-                    "`unmask` security_opt is not supported for pods"
-                )),
-            }
-        },
-    )
-}
-
-/*
-fn ports_try_into_container_ports(ports: Ports) -> color_eyre::Result<Vec<ContainerPort>> {
-    match ports {
-        Ports::Short(ports) => ports
-            .into_iter()
-            .map(|port| parse_container_port_from_short(&port))
-            .collect(),
-        Ports::Long(ports) => ports
-            .into_iter()
-            .map(|port| {
-                eyre::ensure!(port.mode.is_none(), "port mode is not supported for pods");
-                Ok(ContainerPort {
-                    container_port: port.target.into(),
-                    host_ip: port.host_ip,
-                    host_port: match port.published {
-                        Some(PublishedPort::Single(host_port)) => Some(host_port.into()),
-                        Some(PublishedPort::Range(_)) => {
-                            eyre::bail!("pods do not support published port ranges")
-                        }
-                        None => None,
-                    },
-                    name: None,
-                    protocol: port.protocol,
-                })
-            })
-            .collect(),
-    }
-}
-*/
-
-fn parse_container_port_from_short(port: &str) -> color_eyre::Result<ContainerPort> {
-    let (port, protocol) = port
-        .split_once('/')
-        .map_or((port, None), |(port, protocol)| {
-            (port, Some(String::from(protocol)))
-        });
-
-    let (host, container_port) = port
-        .rsplit_once(':')
-        .map_or((None, port), |(host, container_port)| {
-            (Some(host), container_port)
-        });
-    let container_port = container_port
-        .parse()
-        .wrap_err_with(|| format!("could not parse `{container_port}` as container_port"))?;
-
-    let (host_ip, host_port) = host
-        .map(|host| {
-            host.split_once(':')
-                .map_or((None, host), |(host_ip, host_port)| {
-                    (Some(String::from(host_ip)), host_port)
-                })
-        })
-        .unzip();
-    let host_port = host_port
-        .map(|host_port| {
-            host_port
-                .parse()
-                .wrap_err_with(|| format!("could not parse `{host_port}` as host_port"))
-        })
-        .transpose()?;
-
-    Ok(ContainerPort {
-        container_port,
-        host_ip: host_ip.flatten(),
-        host_port,
-        name: None,
-        protocol,
-    })
-}
-
-/*
-fn environment_into_env_vars(environment: Environment) -> Vec<EnvVar> {
-    match environment {
-        Environment::List(environment) => environment
-            .into_iter()
-            .map(|env_var| {
-                let (name, value) = env_var
-                    .split_once('=')
-                    .map(|(name, value)| (String::from(name), String::from(value)))
-                    .unzip();
-                EnvVar {
-                    name: name.unwrap_or(env_var),
-                    value,
-                    value_from: None,
-                }
-            })
-            .collect(),
-        Environment::KvPair(environment) => environment
-            .into_iter()
-            .map(|(name, value)| EnvVar {
-                name,
-                value: value.as_ref().map(ToString::to_string),
-                value_from: None,
-            })
-            .collect(),
-    }
-}
-
-fn ulimits_into_resources(ulimits: Ulimits) -> Option<ResourceRequirements> {
-    (!ulimits.is_empty()).then(|| ResourceRequirements {
-        claims: None,
-        limits: Some(
-            ulimits
-                .0
+        let spec =
+            services
                 .into_iter()
-                .map(|(name, ulimit)| {
-                    let limit = match ulimit {
-                        Ulimit::Single(limit) => limit,
-                        Ulimit::SoftHard { soft: _, hard } => hard,
-                    };
-                    (name, Quantity(limit.to_string()))
-                })
-                .collect(),
-        ),
-        requests: None,
-    })
-}
-*/
+                .try_fold(PodSpec::default(), |mut spec, (name, service)| {
+                    Service::from_compose(&name, service)
+                        .add_to_pod_spec(&mut spec)
+                        .wrap_err_with(|| {
+                            format!("error adding service `{name}` to Kubernetes pod spec")
+                        })
+                        .map(|()| spec)
+                })?;
 
-fn parse_tmpfs_volume_mount(tmpfs: &str, container_name: &str) -> (VolumeMount, Volume) {
-    let name = volume_name(container_name, tmpfs);
-    let volume_mount = volume_mount(String::from(tmpfs), name.clone(), false);
-    (volume_mount, tmpfs_volume(name, None))
-}
+        let pod = Pod {
+            metadata: ObjectMeta {
+                name: Some(name.clone()),
+                ..ObjectMeta::default()
+            },
+            spec: Some(spec),
+            status: None,
+        };
 
-/*
-fn compose_volumes_try_into_volume_mounts(
-    volumes: Vec<ComposeVolumes>,
-    container_name: &str,
-) -> color_eyre::Result<Vec<(VolumeMount, Volume)>> {
-    volumes
-        .into_iter()
-        .map(|volume| match volume {
-            ComposeVolumes::Simple(volume) => parse_short_volume(volume, container_name),
-            ComposeVolumes::Advanced(volume) => {
-                advanced_volume_try_into_volume_mount(volume, container_name)
-            }
-        })
-        .collect()
-}
-*/
-
-fn parse_short_volume(
-    volume: String,
-    container_name: &str,
-) -> color_eyre::Result<(VolumeMount, Volume)> {
-    let mut split = volume.split(':');
-    match split.clone().count() {
-        // anonymous volume, no options
-        1 => {
-            let name = volume_name(container_name, &volume);
-            Ok((
-                volume_mount(volume, name.clone(), false),
-                anonymous_volume(name),
-            ))
-        }
-
-        // anonymous volume with options, named volume, or bind mount
-        2 => {
-            let source_or_target = split.next().expect("split has 2 elements");
-            let target_or_options = split.next().expect("split has 2 elements");
-
-            if target_or_options.contains('/') {
-                // named volume or bind mount
-                let source = source_or_target;
-                let target = target_or_options;
-
-                if source.starts_with(['.', '/', '~']) {
-                    // bind mount
-                    let name = volume_name(container_name, target);
-                    Ok((
-                        volume_mount(String::from(target), name.clone(), false),
-                        bind_volume(name, String::from(source)),
-                    ))
-                } else {
-                    // named volume
-                    let name = String::from(source);
-                    Ok((
-                        volume_mount(String::from(target), name.clone(), false),
-                        named_volume(name),
-                    ))
-                }
-            } else {
-                // anonymous volume with options
-                let target = source_or_target;
-                let options = target_or_options;
-
-                let (target, read_only) = parse_target_and_read_only(target, options);
-
-                let name = volume_name(container_name, &target);
-                Ok((
-                    volume_mount(target, name.clone(), read_only),
-                    anonymous_volume(name),
-                ))
-            }
-        }
-
-        // named volume or bind mount with options
-        3 => {
-            let source = split.next().expect("split has 3 elements");
-            let target = split.next().expect("split has 3 elements");
-            let options = split.next().expect("split has 3 elements");
-
-            let (target_with_options, read_only) = parse_target_and_read_only(target, options);
-
-            if source.starts_with(['.', '/', '~']) {
-                // bind mount with options
-                let name = volume_name(container_name, target);
-                Ok((
-                    volume_mount(target_with_options, name.clone(), read_only),
-                    bind_volume(name, String::from(source)),
-                ))
-            } else {
-                // named volume with options
-                let name = String::from(source);
-                Ok((
-                    volume_mount(target_with_options, name.clone(), read_only),
-                    named_volume(name),
-                ))
-            }
-        }
-
-        _ => eyre::bail!("too many `:` in volume definition"),
-    }
-}
-
-fn parse_target_and_read_only(target: &str, options: &str) -> (String, bool) {
-    let mut read_only = false;
-    let target = options
-        .split(',')
-        .fold(String::from(target), |target, option| {
-            if option == "ro" {
-                read_only = true;
-                target
-            } else if option == "rw" {
-                target
-            } else if target.contains(':') {
-                target + "," + option
-            } else {
-                target + ":" + option
-            }
-        });
-    (target, read_only)
-}
-
-/*
-fn advanced_volume_try_into_volume_mount(
-    volume: AdvancedVolumes,
-    container_name: &str,
-) -> color_eyre::Result<(VolumeMount, Volume)> {
-    let AdvancedVolumes {
-        source,
-        target,
-        _type: kind,
-        read_only,
-        bind,
-        volume,
-        tmpfs,
-    } = volume;
-
-    let volume = match kind.as_str() {
-        "bind" => {
-            eyre::ensure!(
-                bind.is_none(),
-                "bind mount propagation is not supported by pods"
-            );
-            let source = source.ok_or_eyre("cannot have a bind mount without a source")?;
-            let name = volume_name(container_name, &target);
-            bind_volume(name, source)
-        }
-        "volume" => {
-            eyre::ensure!(
-                volume.is_none(),
-                "volume nocopy option is not supported by pods"
-            );
-            source.map_or_else(
-                || -> color_eyre::Result<_> {
-                    let name = volume_name(container_name, &target);
-                    Ok(anonymous_volume(name))
-                },
-                |source| Ok(named_volume(source)),
-            )?
-        }
-        "tmpfs" => {
-            let name = volume_name(container_name, &target);
-            tmpfs_volume(name, tmpfs.map(|settings| settings.size))
-        }
-        _ => eyre::bail!("unsupported volume type: `{kind}`"),
-    };
-
-    Ok((volume_mount(target, volume.name.clone(), read_only), volume))
-}
-*/
-
-fn volume_name(container_name: &str, path: &str) -> String {
-    format!("{container_name}{}", path.replace(['/', '\\'], "-"))
-}
-
-fn volume_mount(mount_path: String, name: String, read_only: bool) -> VolumeMount {
-    VolumeMount {
-        mount_path,
-        mount_propagation: None,
-        name,
-        read_only: read_only.then_some(true),
-        sub_path: None,
-        sub_path_expr: None,
-    }
-}
-
-fn tmpfs_volume(name: String, size_limit: Option<u64>) -> Volume {
-    Volume {
-        name,
-        empty_dir: Some(EmptyDirVolumeSource {
-            medium: Some(String::from("Memory")),
-            size_limit: size_limit.map(|size_limit| Quantity(size_limit.to_string())),
-        }),
-        aws_elastic_block_store: None,
-        azure_disk: None,
-        azure_file: None,
-        cephfs: None,
-        cinder: None,
-        config_map: None,
-        csi: None,
-        downward_api: None,
-        ephemeral: None,
-        fc: None,
-        flex_volume: None,
-        flocker: None,
-        gce_persistent_disk: None,
-        git_repo: None,
-        glusterfs: None,
-        host_path: None,
-        iscsi: None,
-        nfs: None,
-        persistent_volume_claim: None,
-        photon_persistent_disk: None,
-        portworx_volume: None,
-        projected: None,
-        quobyte: None,
-        rbd: None,
-        scale_io: None,
-        secret: None,
-        storageos: None,
-        vsphere_volume: None,
-    }
-}
-
-fn anonymous_volume(name: String) -> Volume {
-    Volume {
-        name,
-        empty_dir: Some(EmptyDirVolumeSource::default()),
-        aws_elastic_block_store: None,
-        azure_disk: None,
-        azure_file: None,
-        cephfs: None,
-        cinder: None,
-        config_map: None,
-        csi: None,
-        downward_api: None,
-        ephemeral: None,
-        fc: None,
-        flex_volume: None,
-        flocker: None,
-        gce_persistent_disk: None,
-        git_repo: None,
-        glusterfs: None,
-        host_path: None,
-        iscsi: None,
-        nfs: None,
-        persistent_volume_claim: None,
-        photon_persistent_disk: None,
-        portworx_volume: None,
-        projected: None,
-        quobyte: None,
-        rbd: None,
-        scale_io: None,
-        secret: None,
-        storageos: None,
-        vsphere_volume: None,
-    }
-}
-
-fn bind_volume(name: String, path: String) -> Volume {
-    Volume {
-        name,
-        host_path: Some(HostPathVolumeSource { path, type_: None }),
-        aws_elastic_block_store: None,
-        azure_disk: None,
-        azure_file: None,
-        cephfs: None,
-        cinder: None,
-        config_map: None,
-        csi: None,
-        downward_api: None,
-        empty_dir: None,
-        ephemeral: None,
-        fc: None,
-        flex_volume: None,
-        flocker: None,
-        gce_persistent_disk: None,
-        git_repo: None,
-        glusterfs: None,
-        iscsi: None,
-        nfs: None,
-        persistent_volume_claim: None,
-        photon_persistent_disk: None,
-        portworx_volume: None,
-        projected: None,
-        quobyte: None,
-        rbd: None,
-        scale_io: None,
-        secret: None,
-        storageos: None,
-        vsphere_volume: None,
-    }
-}
-
-fn named_volume(name: String) -> Volume {
-    Volume {
-        name: name.clone(),
-        persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
-            claim_name: name,
-            read_only: None,
-        }),
-        aws_elastic_block_store: None,
-        azure_disk: None,
-        azure_file: None,
-        cephfs: None,
-        cinder: None,
-        config_map: None,
-        csi: None,
-        downward_api: None,
-        empty_dir: None,
-        ephemeral: None,
-        fc: None,
-        flex_volume: None,
-        flocker: None,
-        gce_persistent_disk: None,
-        git_repo: None,
-        glusterfs: None,
-        host_path: None,
-        iscsi: None,
-        nfs: None,
-        photon_persistent_disk: None,
-        portworx_volume: None,
-        projected: None,
-        quobyte: None,
-        rbd: None,
-        scale_io: None,
-        secret: None,
-        storageos: None,
-        vsphere_volume: None,
-    }
-}
-
-/*
-fn compose_volume_try_into_persistent_volume_claim(
-    compose_volume: ComposeVolume,
-    name: String,
-) -> color_eyre::Result<PersistentVolumeClaim> {
-    eyre::ensure!(
-        compose_volume.external.is_none() && compose_volume.name.is_none(),
-        "external volumes are not supported"
-    );
-
-    let annotations: BTreeMap<_, _> = compose_volume
-        .driver
-        .map(|driver| Ok((String::from("volume.podman.io/driver"), driver)))
-        .into_iter()
-        .chain(driver_opts_try_into_annotations(compose_volume.driver_opts))
-        .collect::<color_eyre::Result<_>>()?;
-
-    let labels: BTreeMap<_, _> = match compose_volume.labels {
-        Labels::List(labels) => labels
+        let persistent_volume_claims = volumes
             .into_iter()
-            .map(|label| {
-                #[allow(clippy::map_unwrap_or)] // map_or_else forces clone of label
-                label
-                    .split_once('=')
-                    .map(|(label, value)| (String::from(label), String::from(value)))
-                    .unwrap_or_else(|| (label, String::new()))
+            .filter_map(|(name, volume)| match volume {
+                Some(Resource::Compose(volume)) if !volume.is_empty() => Some(
+                    volume::try_into_persistent_volume_claim(name.clone(), volume).wrap_err_with(
+                        || format!("error converting volume `{name}` to a persistent volume claim"),
+                    ),
+                ),
+                _ => None,
             })
-            .collect(),
-        Labels::Map(labels) => labels.into_iter().collect(),
-    };
+            .collect::<Result<_, _>>()?;
 
-    Ok(PersistentVolumeClaim {
-        metadata: ObjectMeta {
-            name: Some(name),
-            annotations: annotations.filter_empty(),
-            labels: labels.filter_empty(),
-            ..ObjectMeta::default()
-        },
-        spec: None,
-        status: None,
-    })
-}
-
-fn driver_opts_try_into_annotations(
-    driver_opts: IndexMap<String, Option<SingleValue>>,
-) -> impl Iterator<Item = color_eyre::Result<(String, String)>> {
-    driver_opts
-        .into_iter()
-        .flat_map(|(option, value)| match option.as_str() {
-            "type" => vec![Ok((
-                String::from("volume.podman.io/type"),
-                value.as_ref().map(ToString::to_string).unwrap_or_default(),
-            ))],
-            "device" => vec![Ok((
-                String::from("volume.podman.io/device"),
-                value.as_ref().map(ToString::to_string).unwrap_or_default(),
-            ))],
-            "o" => value
-                .map(|value| MountOptions::from(value.to_string()))
-                .unwrap_or_default()
-                .into_annotations()
-                .map(Ok)
-                .collect(),
-            _ => vec![Err(eyre::eyre!(
-                "unsupported volume driver_opt: `{option}`"
-            ))],
+        Ok(Self {
+            name,
+            pod,
+            persistent_volume_claims,
         })
-}
-*/
-
-#[derive(Debug, Default)]
-struct MountOptions {
-    uid: Option<String>,
-    gid: Option<String>,
-    options: Option<String>,
-}
-
-impl From<String> for MountOptions {
-    fn from(value: String) -> Self {
-        value
-            .split(',')
-            .fold(Self::default(), |mut mount_options, option| {
-                if option.starts_with("uid=") {
-                    let (_, uid) = option
-                        .split_once('=')
-                        .expect("delimiter is in if expression");
-                    mount_options.uid = Some(String::from(uid));
-                    mount_options
-                } else if option.starts_with("gid=") {
-                    let (_, gid) = option
-                        .split_once('=')
-                        .expect("delimiter is in if expression");
-                    mount_options.gid = Some(String::from(gid));
-                    mount_options
-                } else if let Some(options) = mount_options.options {
-                    mount_options.options = Some(options + "," + option);
-                    mount_options
-                } else {
-                    mount_options.options = Some(String::from(option));
-                    mount_options
-                }
-            })
     }
 }
 
-impl MountOptions {
-    fn into_annotations(self) -> impl Iterator<Item = (String, String)> {
-        self.uid
-            .map(|uid| (String::from("volume.podman.io/uid"), uid))
-            .into_iter()
-            .chain(
-                self.gid
-                    .map(|gid| (String::from("volume.podman.io/gid"), gid)),
-            )
-            .chain(
-                self.options
-                    .map(|options| (String::from("volume.podman.io/mount-options"), options)),
-            )
-    }
-}
+impl Display for File {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let Self {
+            name: _,
+            pod,
+            persistent_volume_claims,
+        } = self;
 
-trait FilterDefault {
-    fn filter_default(self) -> Option<Self>
-    where
-        Self: Sized;
-}
+        for volume in persistent_volume_claims {
+            f.write_str(&serde_yaml::to_string(volume).map_err(|_| fmt::Error)?)?;
+            writeln!(f, "---")?;
+        }
 
-impl<T: Default + PartialEq<T>> FilterDefault for T {
-    fn filter_default(self) -> Option<Self> {
-        (self != Self::default()).then_some(self)
-    }
-}
-
-trait FilterEmpty {
-    fn filter_empty(self) -> Option<Self>
-    where
-        Self: Sized;
-}
-
-impl<T> FilterEmpty for Vec<T> {
-    fn filter_empty(self) -> Option<Self> {
-        (!self.is_empty()).then_some(self)
-    }
-}
-
-impl<K, V> FilterEmpty for BTreeMap<K, V> {
-    fn filter_empty(self) -> Option<Self> {
-        (!self.is_empty()).then_some(self)
+        f.write_str(&serde_yaml::to_string(pod).map_err(|_| fmt::Error)?)
     }
 }

--- a/src/cli/k8s.rs
+++ b/src/cli/k8s.rs
@@ -4,11 +4,13 @@ use color_eyre::{
     eyre::{self, Context, OptionExt},
     Help,
 };
+/*
 use docker_compose_types::{
     AdvancedVolumes, Compose, ComposeVolume, Entrypoint, Environment, Healthcheck, HealthcheckTest,
     Labels, Ports, PublishedPort, Service, SingleValue, Tmpfs, Ulimit, Ulimits,
     Volumes as ComposeVolumes,
 };
+*/
 use indexmap::IndexMap;
 use k8s_openapi::{
     api::core::v1::{
@@ -24,6 +26,7 @@ use super::{
     container::security_opt::{LabelOpt, SecurityOpt},
 };
 
+/*
 pub fn compose_try_into_pod(
     mut compose: Compose,
     name: String,
@@ -288,6 +291,7 @@ fn healthcheck_try_into_probe(healthcheck: Healthcheck) -> color_eyre::Result<Pr
         ..Probe::default()
     })
 }
+*/
 
 fn parse_seconds(duration: &str) -> color_eyre::Result<i32> {
     duration_str::parse(duration)
@@ -365,6 +369,7 @@ fn security_opts_try_into_se_linux_options(
     )
 }
 
+/*
 fn ports_try_into_container_ports(ports: Ports) -> color_eyre::Result<Vec<ContainerPort>> {
     match ports {
         Ports::Short(ports) => ports
@@ -392,6 +397,7 @@ fn ports_try_into_container_ports(ports: Ports) -> color_eyre::Result<Vec<Contai
             .collect(),
     }
 }
+*/
 
 fn parse_container_port_from_short(port: &str) -> color_eyre::Result<ContainerPort> {
     let (port, protocol) = port
@@ -434,6 +440,7 @@ fn parse_container_port_from_short(port: &str) -> color_eyre::Result<ContainerPo
     })
 }
 
+/*
 fn environment_into_env_vars(environment: Environment) -> Vec<EnvVar> {
     match environment {
         Environment::List(environment) => environment
@@ -480,6 +487,7 @@ fn ulimits_into_resources(ulimits: Ulimits) -> Option<ResourceRequirements> {
         requests: None,
     })
 }
+*/
 
 fn parse_tmpfs_volume_mount(tmpfs: &str, container_name: &str) -> (VolumeMount, Volume) {
     let name = volume_name(container_name, tmpfs);
@@ -487,6 +495,7 @@ fn parse_tmpfs_volume_mount(tmpfs: &str, container_name: &str) -> (VolumeMount, 
     (volume_mount, tmpfs_volume(name, None))
 }
 
+/*
 fn compose_volumes_try_into_volume_mounts(
     volumes: Vec<ComposeVolumes>,
     container_name: &str,
@@ -501,6 +510,7 @@ fn compose_volumes_try_into_volume_mounts(
         })
         .collect()
 }
+*/
 
 fn parse_short_volume(
     volume: String,
@@ -605,6 +615,7 @@ fn parse_target_and_read_only(target: &str, options: &str) -> (String, bool) {
     (target, read_only)
 }
 
+/*
 fn advanced_volume_try_into_volume_mount(
     volume: AdvancedVolumes,
     container_name: &str,
@@ -651,6 +662,7 @@ fn advanced_volume_try_into_volume_mount(
 
     Ok((volume_mount(target, volume.name.clone(), read_only), volume))
 }
+*/
 
 fn volume_name(container_name: &str, path: &str) -> String {
     format!("{container_name}{}", path.replace(['/', '\\'], "-"))
@@ -813,6 +825,7 @@ fn named_volume(name: String) -> Volume {
     }
 }
 
+/*
 fn compose_volume_try_into_persistent_volume_claim(
     compose_volume: ComposeVolume,
     name: String,
@@ -880,6 +893,7 @@ fn driver_opts_try_into_annotations(
             ))],
         })
 }
+*/
 
 #[derive(Debug, Default)]
 struct MountOptions {

--- a/src/cli/k8s/service.rs
+++ b/src/cli/k8s/service.rs
@@ -1,0 +1,929 @@
+//! [`Service`] is created from a [`compose_spec::Service`] and then added to a [`PodSpec`].
+
+mod mount;
+
+use std::{collections::BTreeMap, net::IpAddr, time::Duration};
+
+use color_eyre::{
+    eyre::{bail, ensure, eyre, OptionExt, WrapErr},
+    Section,
+};
+use compose_spec::{
+    service::{
+        build::Context,
+        device::CgroupRule,
+        healthcheck::{self, Test},
+        ports::{self, Port, Protocol},
+        AbsolutePath, BlkioConfig, Build, ByteValue, Cgroup, Command, ConfigOrSecret, CpuSet, Cpus,
+        CredentialSpec, DependsOn, Deploy, Develop, Device, EnvFile, Expose, Extends, Healthcheck,
+        Hostname, Image, Ipc, Limit, Link, Logging, MacAddress, NetworkConfig, OomScoreAdj,
+        Percent, Platform, Ports, PullPolicy, Restart, Ulimits, UserOrGroup, Uts, Volumes,
+        VolumesFrom,
+    },
+    Extensions, Identifier, ItemOrList, ListOrMap, Map, ShortOrLong,
+};
+use indexmap::{IndexMap, IndexSet};
+use k8s_openapi::{
+    api::core::v1::{
+        Capabilities, Container, ContainerPort, EnvVar, ExecAction, PodSpec, Probe,
+        ResourceRequirements, SELinuxOptions, SecurityContext,
+    },
+    apimachinery::pkg::api::resource::Quantity,
+};
+
+use crate::cli::{
+    compose::command_try_into_vec,
+    container::security_opt::{LabelOpt, SecurityOpt},
+};
+
+use self::mount::tmpfs_and_volumes_try_into_volume_mounts;
+
+/// Fields from a [`compose_spec::Service`] which will be [added](Service::add_to_pod_spec()) to a
+/// [`PodSpec`]'s [`Container`]s and [`Volume`](k8s_openapi::api::core::v1::Volume)s.
+#[allow(clippy::struct_excessive_bools)]
+pub(super) struct Service {
+    unsupported: Unsupported,
+    name: Identifier,
+    resources: ContainerResources,
+    security_context: ContainerSecurityContext,
+    command: Option<Command>,
+    entrypoint: Option<Command>,
+    environment: ListOrMap,
+    healthcheck: Option<Healthcheck>,
+    image: Option<Image>,
+    ports: Ports,
+    pull_policy: Option<PullPolicy>,
+    stdin_open: bool,
+    tmpfs: Option<ItemOrList<AbsolutePath>>,
+    tty: bool,
+    volumes: Volumes,
+    working_dir: Option<AbsolutePath>,
+}
+
+impl Service {
+    /// Create a [`Service`] from a `name` [`Identifier`] and a [`compose_spec::Service`].
+    pub(super) fn from_compose(
+        name: &Identifier,
+        compose_spec::Service {
+            attach,
+            build,
+            blkio_config,
+            cpu_count,
+            cpu_percent,
+            cpu_shares,
+            cpu_period,
+            cpu_quota,
+            cpu_rt_runtime,
+            cpu_rt_period,
+            cpus,
+            cpuset,
+            cap_add,
+            cap_drop,
+            cgroup,
+            cgroup_parent,
+            command,
+            configs,
+            container_name,
+            credential_spec,
+            depends_on,
+            deploy,
+            develop,
+            device_cgroup_rules,
+            devices,
+            dns,
+            dns_opt,
+            dns_search,
+            domain_name,
+            entrypoint,
+            env_file,
+            environment,
+            expose,
+            extends,
+            annotations,
+            external_links,
+            extra_hosts,
+            group_add,
+            healthcheck,
+            hostname,
+            image,
+            init,
+            ipc,
+            uts,
+            isolation,
+            labels,
+            links,
+            logging,
+            network_config,
+            mac_address,
+            mem_limit,
+            mem_reservation,
+            mem_swappiness,
+            memswap_limit,
+            oom_kill_disable,
+            oom_score_adj,
+            pid,
+            pids_limit,
+            platform,
+            ports,
+            privileged,
+            profiles,
+            pull_policy,
+            read_only,
+            restart,
+            runtime,
+            scale,
+            secrets,
+            security_opt,
+            shm_size,
+            stdin_open,
+            stop_grace_period,
+            stop_signal,
+            storage_opt,
+            sysctls,
+            tmpfs,
+            tty,
+            ulimits,
+            user,
+            userns_mode,
+            volumes,
+            volumes_from,
+            working_dir,
+            extensions,
+        }: compose_spec::Service,
+    ) -> Self {
+        Self {
+            unsupported: Unsupported {
+                attach,
+                build,
+                blkio_config,
+                cpu_count,
+                cpu_percent,
+                cpu_shares,
+                cpu_period,
+                cpu_quota,
+                cpu_rt_runtime,
+                cpu_rt_period,
+                cpuset,
+                cgroup,
+                cgroup_parent,
+                configs,
+                credential_spec,
+                depends_on,
+                deploy,
+                develop,
+                device_cgroup_rules,
+                devices,
+                dns,
+                dns_opt,
+                dns_search,
+                domain_name,
+                env_file,
+                expose,
+                extends,
+                annotations,
+                external_links,
+                extra_hosts,
+                group_add,
+                hostname,
+                init,
+                ipc,
+                uts,
+                isolation,
+                labels,
+                links,
+                logging,
+                network_config,
+                mac_address,
+                mem_swappiness,
+                memswap_limit,
+                oom_kill_disable,
+                oom_score_adj,
+                pid,
+                pids_limit,
+                platform,
+                profiles,
+                restart,
+                runtime,
+                scale,
+                secrets,
+                shm_size,
+                stop_grace_period,
+                stop_signal,
+                storage_opt,
+                sysctls,
+                ulimits,
+                userns_mode,
+                volumes_from,
+                extensions,
+            },
+            name: container_name.unwrap_or_else(|| name.clone()),
+            resources: ContainerResources {
+                cpus,
+                mem_limit,
+                mem_reservation,
+            },
+            security_context: ContainerSecurityContext {
+                cap_add,
+                cap_drop,
+                privileged,
+                read_only,
+                security_opt,
+                user,
+            },
+            command,
+            entrypoint,
+            environment,
+            healthcheck,
+            image,
+            ports,
+            pull_policy,
+            stdin_open,
+            tmpfs,
+            tty,
+            volumes,
+            working_dir,
+        }
+    }
+
+    /// Add the service to a [`PodSpec`]'s [`Container`]s and [`Volume`]s.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an unsupported option was used or conversion of one of the fields fails.
+    pub(super) fn add_to_pod_spec(self, spec: &mut PodSpec) -> color_eyre::Result<()> {
+        let Self {
+            unsupported,
+            name,
+            resources,
+            security_context,
+            command,
+            entrypoint,
+            environment,
+            healthcheck,
+            image,
+            ports,
+            pull_policy,
+            stdin_open,
+            tmpfs,
+            tty,
+            volumes,
+            working_dir,
+        } = self;
+
+        unsupported.ensure_empty()?;
+
+        let volume_mounts =
+            tmpfs_and_volumes_try_into_volume_mounts(tmpfs, volumes, &name, &mut spec.volumes)
+                // converting `tmpfs` always succeeds
+                .wrap_err("error converting `volumes`")?;
+
+        spec.containers.push(Container {
+            name: name.into(),
+            resources: resources.into_resource_requirements(),
+            security_context: security_context.try_into_security_context()?,
+            args: command
+                .map(command_try_into_vec)
+                .transpose()
+                .wrap_err("error converting `command` to `args`")?,
+            command: entrypoint.map(|entrypoint| match entrypoint {
+                Command::String(entrypoint) => {
+                    vec!["/bin/sh".to_owned(), "-c".to_owned(), entrypoint]
+                }
+                Command::List(entrypoint) => entrypoint,
+            }),
+            env: (!environment.is_empty())
+                .then(|| {
+                    environment.into_map().map(|environment| {
+                        environment
+                            .into_iter()
+                            .map(|(name, value)| EnvVar {
+                                name: name.into(),
+                                value: value.map(Into::into),
+                                value_from: None,
+                            })
+                            .collect()
+                    })
+                })
+                .transpose()
+                .wrap_err("error converting `environment`")?,
+            liveness_probe: healthcheck
+                .and_then(|healthcheck| match healthcheck {
+                    Healthcheck::Command(command) => {
+                        Some(healthcheck_command_try_into_probe(command))
+                    }
+                    // container image healthchecks are disabled by default in k8s
+                    Healthcheck::Disable => None,
+                })
+                .transpose()
+                .wrap_err("error converting `healthcheck`")?,
+            image: Some(image.ok_or_eyre("`image` is required")?.into_inner()),
+            ports: (!ports.is_empty())
+                .then(|| {
+                    ports::into_long_iter(ports)
+                        .map(port_try_into_container_port)
+                        .collect()
+                })
+                .transpose()
+                .wrap_err("error converting `ports`")?,
+            image_pull_policy: pull_policy
+                .map(|pull_policy| match pull_policy {
+                    PullPolicy::Always => Ok("Always".to_owned()),
+                    PullPolicy::Never => Ok("Never".to_owned()),
+                    PullPolicy::Missing => Ok("IfNotPreset".to_owned()),
+                    PullPolicy::Build => Err(eyre!("`build` is not supported")),
+                })
+                .transpose()
+                .wrap_err("error converting `pull_policy`")?,
+            stdin: stdin_open.then_some(true),
+            tty: tty.then_some(true),
+            volume_mounts: (!volume_mounts.is_empty()).then_some(volume_mounts),
+            working_dir: working_dir
+                .map(|path| {
+                    path.into_inner()
+                        .into_os_string()
+                        .into_string()
+                        .map_err(|_| eyre!("`working_dir` must contain only valid UTF-8"))
+                })
+                .transpose()?,
+            ..Container::default()
+        });
+
+        Ok(())
+    }
+}
+
+/// Attempt to convert a [`compose_spec::Service`]'s [`healthcheck::Command`] into a Kubernetes
+/// [`Probe`] for use in the `liveness_probe` field of [`Container`].
+///
+/// # Errors
+///
+/// Returns an error if extensions are present or there was an error converting one of the
+/// [`Duration`]s into seconds.
+fn healthcheck_command_try_into_probe(
+    healthcheck::Command {
+        test,
+        interval,
+        timeout,
+        retries,
+        start_period,
+        // k8s doesn't run probes during startup
+        start_interval: _,
+        extensions,
+    }: healthcheck::Command,
+) -> color_eyre::Result<Probe> {
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    Ok(Probe {
+        exec: test.map(|test| ExecAction {
+            command: Some(match test {
+                Test::Command(test) => test,
+                Test::ShellCommand(test) => vec!["/bin/sh".to_owned(), "-c".to_owned(), test],
+            }),
+        }),
+        period_seconds: interval
+            .map(duration_round_seconds)
+            .map(TryInto::try_into)
+            .transpose()
+            .wrap_err("error converting `interval`")?,
+        timeout_seconds: Some(
+            timeout
+                .map(duration_round_seconds)
+                .map(TryInto::try_into)
+                .transpose()
+                .wrap_err("error converting `timeout`")?
+                // default timeout for compose is 30 seconds, for k8s its 1 second
+                .unwrap_or(30),
+        ),
+        failure_threshold: retries
+            .map(TryInto::try_into)
+            .transpose()
+            .wrap_err("error converting `retries`")?,
+        initial_delay_seconds: start_period
+            .map(duration_round_seconds)
+            .map(TryInto::try_into)
+            .transpose()
+            .wrap_err("error converting `start_period`")?,
+        ..Probe::default()
+    })
+}
+
+/// Round a [`Duration`] to the nearest whole seconds with a minimum of 1 second.
+fn duration_round_seconds(duration: Duration) -> u64 {
+    let mut secs = duration.as_secs();
+    // rounding
+    if duration.subsec_micros() >= 500_000 {
+        secs += 1;
+    }
+    // floor of 1
+    secs.max(1)
+}
+
+/// Attempt to convert a [`compose_spec::Service`]'s [`Port`] into a Kubernetes [`ContainerPort`].
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is used.
+fn port_try_into_container_port(
+    Port {
+        name,
+        target,
+        published,
+        host_ip,
+        protocol,
+        app_protocol,
+        mode,
+        extensions,
+    }: Port,
+) -> color_eyre::Result<ContainerPort> {
+    ensure!(app_protocol.is_none(), "`app_protocol` is not supported");
+    ensure!(mode.is_none(), "`mode` is not supported");
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    Ok(ContainerPort {
+        name,
+        container_port: target.into(),
+        host_port: published
+            .map(|range| {
+                ensure!(
+                    range.size() == 1,
+                    "Kubernetes only supports publishing to a single, specific, host port, \
+                        as apposed to one of a range of ports"
+                );
+                Ok(range.start().into())
+            })
+            .transpose()
+            .wrap_err("error converting `published`")?,
+        host_ip: host_ip.as_ref().map(ToString::to_string),
+        protocol: protocol
+            .map(|protocol| match protocol {
+                Protocol::Tcp => Ok("TCP".to_owned()),
+                Protocol::Udp => Ok("UDP".to_owned()),
+                Protocol::Other(mut protocol) => {
+                    protocol.make_ascii_uppercase();
+                    ensure!(
+                        protocol == "SCTP",
+                        "only `UDP`, `TCP`, and `SCTP` are supported"
+                    );
+                    Ok(protocol)
+                }
+            })
+            .transpose()
+            .wrap_err("error converting `protocol`")?,
+    })
+}
+
+/// Fields from a [`compose_spec::Service`] which are converted into a [`Container`]'s
+/// [`ResourceRequirements`].
+struct ContainerResources {
+    cpus: Option<Cpus>,
+    mem_limit: Option<ByteValue>,
+    mem_reservation: Option<ByteValue>,
+}
+
+impl ContainerResources {
+    /// Convert into [`ResourceRequirements`] for a Kubernetes [`Container`].
+    ///
+    /// Returns [`None`] if no resource options are set.
+    fn into_resource_requirements(self) -> Option<ResourceRequirements> {
+        let Self {
+            cpus,
+            mem_limit,
+            mem_reservation,
+        } = self;
+
+        let mut resources = None;
+
+        if let Some(cpus) = cpus {
+            resources
+                .get_or_insert_with(ResourceRequirements::default)
+                .limits
+                .get_or_insert_with(BTreeMap::default)
+                .insert("cpu".to_owned(), Quantity(cpus.into_inner().to_string()));
+        }
+
+        if let Some(mem_limit) = mem_limit {
+            resources
+                .get_or_insert_with(ResourceRequirements::default)
+                .limits
+                .get_or_insert_with(BTreeMap::default)
+                .insert("memory".to_owned(), Quantity(mem_limit.to_string()));
+        }
+
+        if let Some(mem_reservation) = mem_reservation {
+            resources
+                .get_or_insert_with(ResourceRequirements::default)
+                .requests
+                .get_or_insert_with(BTreeMap::default)
+                .insert("memory".to_owned(), Quantity(mem_reservation.to_string()));
+        }
+
+        resources
+    }
+}
+
+/// Fields from a [`compose_spec::Service`] which are converted into a [`Container`]'s
+/// [`SecurityContext`].
+struct ContainerSecurityContext {
+    cap_add: IndexSet<String>,
+    cap_drop: IndexSet<String>,
+    privileged: bool,
+    read_only: bool,
+    security_opt: IndexSet<String>,
+    user: Option<UserOrGroup>,
+}
+
+impl ContainerSecurityContext {
+    /// Attempt to convert into [`SecurityContext`] for a Kubernetes [`Container`].
+    ///
+    /// Returns [`None`] if no security context options are set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conversion of one of the fields fails.
+    fn try_into_security_context(self) -> color_eyre::Result<Option<SecurityContext>> {
+        let Self {
+            cap_add,
+            cap_drop,
+            privileged,
+            read_only,
+            security_opt,
+            user,
+        } = self;
+
+        let mut security_context = None;
+
+        if !cap_add.is_empty() {
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .capabilities
+                .get_or_insert_with(Capabilities::default)
+                .add = Some(cap_add.into_iter().collect());
+        }
+
+        if !cap_drop.is_empty() {
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .capabilities
+                .get_or_insert_with(Capabilities::default)
+                .drop = Some(cap_drop.into_iter().collect());
+        }
+
+        if privileged {
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .privileged = Some(true);
+        }
+
+        if read_only {
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .read_only_root_filesystem = Some(true);
+        }
+
+        if !security_opt.is_empty() {
+            let se_linux_options = security_opt_try_into_selinux_options(security_opt)
+                .wrap_err("error converting `security_opt`")?;
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .se_linux_options = Some(se_linux_options);
+        }
+
+        if let Some(user) = user {
+            let user = match user {
+                UserOrGroup::Id(user) => user,
+                UserOrGroup::Name(_) => bail!("only numeric UIDs are supported for `user`"),
+            };
+            security_context
+                .get_or_insert_with(SecurityContext::default)
+                .run_as_user = Some(user.into());
+        }
+
+        Ok(security_context)
+    }
+}
+
+/// Attempt to convert a [`compose_spec::Service`]'s `security_opt` field into [`SELinuxOptions`].
+///
+/// # Errors
+///
+/// Returns an error if an unknown or unsupported security opt is given.
+fn security_opt_try_into_selinux_options(
+    security_opt: IndexSet<String>,
+) -> color_eyre::Result<SELinuxOptions> {
+    security_opt.into_iter().try_fold(
+        SELinuxOptions::default(),
+        |mut selinux_options, security_opt| {
+            let security_opt = if security_opt == "no-new-privileges:true" {
+                SecurityOpt::NoNewPrivileges
+            } else if security_opt == "no-new-privileges:false" {
+                return Ok(selinux_options);
+            } else {
+                security_opt.replacen(':', "=", 1).parse()?
+            };
+
+            match security_opt {
+                SecurityOpt::Apparmor(_) => Err(eyre!("`apparmor` security_opt is not supported")),
+                SecurityOpt::Label(label_opt) => match label_opt {
+                    LabelOpt::User(user) => {
+                        selinux_options.user = Some(user);
+                        Ok(selinux_options)
+                    }
+                    LabelOpt::Role(role) => {
+                        selinux_options.role = Some(role);
+                        Ok(selinux_options)
+                    }
+                    LabelOpt::Type(kind) => {
+                        selinux_options.type_ = Some(kind);
+                        Ok(selinux_options)
+                    }
+                    LabelOpt::Level(level) => {
+                        selinux_options.level = Some(level);
+                        Ok(selinux_options)
+                    }
+                    LabelOpt::Filetype(_) => {
+                        Err(eyre!("`label:filetype` security_opt is not supported"))
+                    }
+                    LabelOpt::Disable => {
+                        Err(eyre!("`label:disable` security_opt is not supported"))
+                    }
+                    LabelOpt::Nested => Err(eyre!("`label:nested` security_opt is not supported")),
+                },
+                SecurityOpt::Mask(_) => Err(eyre!("`mask` security_opt is not supported")),
+                SecurityOpt::NoNewPrivileges => {
+                    Err(eyre!("`no-new-privileges` security_opt is not supported"))
+                }
+                SecurityOpt::Seccomp(_) => Err(eyre!("`seccomp` security_opt is not supported")),
+                SecurityOpt::ProcOpts(_) => Err(eyre!("`proc-opts` security_opt is not supported")),
+                SecurityOpt::Unmask(_) => Err(eyre!("`unmask` security_opt is not supported")),
+            }
+        },
+    )
+}
+
+/// Fields taken from a [`compose_spec::Service`] which are not supported for Kubernetes pod
+/// [`Container`]s.
+struct Unsupported {
+    attach: bool,
+    build: Option<ShortOrLong<Context, Build>>,
+    blkio_config: Option<BlkioConfig>,
+    cpu_count: Option<u64>,
+    cpu_percent: Option<Percent>,
+    cpu_shares: Option<u64>,
+    cpu_period: Option<Duration>,
+    cpu_quota: Option<Duration>,
+    cpu_rt_runtime: Option<Duration>,
+    cpu_rt_period: Option<Duration>,
+    cpuset: CpuSet,
+    cgroup: Option<Cgroup>,
+    cgroup_parent: Option<String>,
+    configs: Vec<ShortOrLong<Identifier, ConfigOrSecret>>,
+    credential_spec: Option<CredentialSpec>,
+    depends_on: DependsOn,
+    deploy: Option<Deploy>,
+    develop: Option<Develop>,
+    device_cgroup_rules: IndexSet<CgroupRule>,
+    devices: IndexSet<Device>,
+    dns: Option<ItemOrList<IpAddr>>,
+    dns_opt: IndexSet<String>,
+    dns_search: Option<ItemOrList<Hostname>>,
+    domain_name: Option<Hostname>,
+    env_file: Option<EnvFile>,
+    expose: IndexSet<Expose>,
+    extends: Option<Extends>,
+    annotations: ListOrMap,
+    external_links: IndexSet<Link>,
+    extra_hosts: IndexMap<Hostname, IpAddr>,
+    group_add: IndexSet<UserOrGroup>,
+    hostname: Option<Hostname>,
+    init: bool,
+    ipc: Option<Ipc>,
+    uts: Option<Uts>,
+    isolation: Option<String>,
+    labels: ListOrMap,
+    links: IndexSet<Link>,
+    logging: Option<Logging>,
+    network_config: Option<NetworkConfig>,
+    mac_address: Option<MacAddress>,
+    mem_swappiness: Option<Percent>,
+    memswap_limit: Option<Limit<ByteValue>>,
+    oom_kill_disable: bool,
+    oom_score_adj: Option<OomScoreAdj>,
+    pid: Option<String>,
+    pids_limit: Option<Limit<u32>>,
+    platform: Option<Platform>,
+    profiles: IndexSet<Identifier>,
+    restart: Option<Restart>,
+    runtime: Option<String>,
+    scale: Option<u64>,
+    secrets: Vec<ShortOrLong<Identifier, ConfigOrSecret>>,
+    shm_size: Option<ByteValue>,
+    stop_grace_period: Option<Duration>,
+    stop_signal: Option<String>,
+    storage_opt: Map,
+    sysctls: ListOrMap,
+    ulimits: Ulimits,
+    userns_mode: Option<String>,
+    volumes_from: IndexSet<VolumesFrom>,
+    extensions: Extensions,
+}
+
+impl Unsupported {
+    /// Ensure that all unsupported fields are [`None`] or empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a field is not empty.
+    #[allow(clippy::too_many_lines)]
+    fn ensure_empty(&self) -> color_eyre::Result<()> {
+        let Self {
+            attach,
+            build,
+            blkio_config,
+            cpu_count,
+            cpu_percent,
+            cpu_shares,
+            cpu_period,
+            cpu_quota,
+            cpu_rt_runtime,
+            cpu_rt_period,
+            cpuset,
+            cgroup,
+            cgroup_parent,
+            configs,
+            credential_spec,
+            depends_on,
+            deploy,
+            develop,
+            device_cgroup_rules,
+            devices,
+            dns,
+            dns_opt,
+            dns_search,
+            domain_name,
+            env_file,
+            expose,
+            extends,
+            annotations,
+            external_links,
+            extra_hosts,
+            group_add,
+            hostname,
+            init,
+            ipc,
+            uts,
+            isolation,
+            labels,
+            links,
+            logging,
+            network_config,
+            mac_address,
+            mem_swappiness,
+            memswap_limit,
+            oom_kill_disable,
+            oom_score_adj,
+            pid,
+            pids_limit,
+            platform,
+            profiles,
+            restart,
+            runtime,
+            scale,
+            secrets,
+            shm_size,
+            stop_grace_period,
+            stop_signal,
+            storage_opt,
+            sysctls,
+            ulimits,
+            userns_mode,
+            volumes_from,
+            extensions,
+        } = self;
+
+        let unsupported_options = [
+            ("attach", *attach),
+            ("build", build.is_none()),
+            ("blkio_config", blkio_config.is_none()),
+            ("cpu_count", cpu_count.is_none()),
+            ("cpu_percent", cpu_percent.is_none()),
+            ("cpu_shares", cpu_shares.is_none()),
+            ("cpu_period", cpu_period.is_none()),
+            ("cpu_quota", cpu_quota.is_none()),
+            ("cpu_rt_runtime", cpu_rt_runtime.is_none()),
+            ("cpu_rt_period", cpu_rt_period.is_none()),
+            ("cpuset", cpuset.is_empty()),
+            ("cgroup", cgroup.is_none()),
+            ("cgroup_parent", cgroup_parent.is_none()),
+            ("configs", configs.is_empty()),
+            ("credential_spec", credential_spec.is_none()),
+            ("depends_on", depends_on_is_empty(depends_on)),
+            ("deploy", deploy.is_none()),
+            ("develop", develop.is_none()),
+            ("device_cgroup_rules", device_cgroup_rules.is_empty()),
+            ("domainname", domain_name.is_none()),
+            ("env_file", env_file.is_none()),
+            ("expose", expose.is_empty()),
+            ("extends", extends.is_none()),
+            ("external_links", external_links.is_empty()),
+            ("group_add", group_add.is_empty()),
+            ("uts", uts.is_none()),
+            ("isolation", isolation.is_none()),
+            ("links", links.is_empty()),
+            ("logging", logging.is_none()),
+            (
+                "network_mode",
+                !matches!(network_config, Some(NetworkConfig::NetworkMode(_))),
+            ),
+            (
+                "networks",
+                !matches!(network_config, Some(NetworkConfig::Networks(_))),
+            ),
+            ("mac_address", mac_address.is_none()),
+            ("mem_swappiness", mem_swappiness.is_none()),
+            ("memswap_limit", memswap_limit.is_none()),
+            ("oom_kill_disable", !oom_kill_disable),
+            ("oom_score_adj", oom_score_adj.is_none()),
+            ("pids_limit", pids_limit.is_none()),
+            ("platform", platform.is_none()),
+            ("profiles", profiles.is_empty()),
+            ("runtime", runtime.is_none()),
+            ("scale", scale.is_none()),
+            ("secrets", secrets.is_empty()),
+            ("shm_size", shm_size.is_none()),
+            ("stop_signal", stop_signal.is_none()),
+            ("storage_opt", storage_opt.is_empty()),
+            ("ulimits", ulimits.is_empty()),
+            ("userns_mode", userns_mode.is_none()),
+            ("volumes_from", volumes_from.is_empty()),
+        ];
+        for (option, not_present) in unsupported_options {
+            ensure!(
+                not_present,
+                "`{option}` is not supported for Kubernetes pod containers"
+            );
+        }
+
+        let pod_spec_options = [
+            ("dns", dns.is_none()),
+            ("dns_opt", dns_opt.is_empty()),
+            ("dns_search", dns_search.is_none()),
+            ("extra_hosts", extra_hosts.is_empty()),
+            ("hostname", hostname.is_none()),
+            ("init", !init),
+            ("ipc", ipc.is_none()),
+            ("pid", pid.is_none()),
+            ("restart", restart.is_none()),
+            ("stop_grace_period", stop_grace_period.is_none()),
+            ("sysctls", sysctls.is_empty()),
+        ];
+        for (option, not_present) in pod_spec_options {
+            if !not_present {
+                return Err(eyre!(
+                    "Kubernetes pods do not support per container `{option}` options",
+                )
+                .suggestion("try using setting the option in the pod spec instead"));
+            }
+        }
+
+        let pod_metadata_options = [
+            ("annotations", annotations.is_empty()),
+            ("labels", labels.is_empty()),
+        ];
+        for (option, not_present) in pod_metadata_options {
+            if !not_present {
+                return Err(eyre!(
+                    "Kubernetes pods do not support per container `{option}` options",
+                )
+                .suggestion("try using setting the option in the pod metadata instead"));
+            }
+        }
+
+        if !devices.is_empty() {
+            return Err(
+                eyre!("Kubernetes pod containers do not directly support devices")
+                    .suggestion("try using a bind mount instead"),
+            );
+        };
+
+        ensure!(
+            extensions.is_empty(),
+            "compose extensions are not supported"
+        );
+
+        Ok(())
+    }
+}
+
+/// Return `true` if the [`DependsOn`] is empty.
+fn depends_on_is_empty(depends_on: &DependsOn) -> bool {
+    match depends_on {
+        ShortOrLong::Short(depends_on) => depends_on.is_empty(),
+        ShortOrLong::Long(depends_on) => depends_on.is_empty(),
+    }
+}

--- a/src/cli/k8s/service/mount.rs
+++ b/src/cli/k8s/service/mount.rs
@@ -1,0 +1,265 @@
+//! Utilities for converting a volume [`Mount`] from a [`compose_spec::Service`] into a Kubernetes
+//! [`VolumeMount`] and [`Volume`] for a [`Container`](k8s_openapi::api::core::v1::Container) and
+//! its [`PodSpec`](k8s_openapi::api::core::v1::PodSpec).
+
+use color_eyre::eyre::{ensure, eyre, WrapErr};
+use compose_spec::{
+    service::{
+        volumes::{
+            self,
+            mount::{self, Bind, BindOptions, Common, Tmpfs, TmpfsOptions, VolumeOptions},
+            Mount,
+        },
+        AbsolutePath, Volumes,
+    },
+    Identifier, ItemOrList,
+};
+use k8s_openapi::{
+    api::core::v1::{
+        EmptyDirVolumeSource, HostPathVolumeSource, PersistentVolumeClaimVolumeSource, Volume,
+        VolumeMount,
+    },
+    apimachinery::pkg::api::resource::Quantity,
+};
+
+/// Attempt to convert the `tmpfs` and `volumes` fields from a [`compose_spec::Service`] into
+/// [`VolumeMount`]s.
+///
+/// The corresponding [`Volume`]s are added to `pod_volumes`.
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is present or the [`Mount`] type is not supported.
+pub(super) fn tmpfs_and_volumes_try_into_volume_mounts(
+    tmpfs: Option<ItemOrList<AbsolutePath>>,
+    volumes: Volumes,
+    container_name: &Identifier,
+    pod_volumes: &mut Option<Vec<Volume>>,
+) -> color_eyre::Result<Vec<VolumeMount>> {
+    tmpfs
+        .into_iter()
+        .flat_map(ItemOrList::into_list)
+        .map(Tmpfs::from_target)
+        .map(Into::into)
+        .chain(volumes::into_long_iter(volumes))
+        .map(|mount| {
+            let (volume_mount, volume) = try_into_volume_mount(mount, container_name)?;
+            pod_volumes.get_or_insert_with(Vec::new).push(volume);
+            Ok(volume_mount)
+        })
+        .collect()
+}
+
+/// Attempt to convert a volume [`Mount`] from a [`compose_spec::Service`] into a [`VolumeMount`]
+/// and its corresponding [`Volume`].
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is present or the [`Mount`] type is not supported.
+fn try_into_volume_mount(
+    mount: Mount,
+    container_name: &Identifier,
+) -> color_eyre::Result<(VolumeMount, Volume)> {
+    match mount {
+        Mount::Volume(volume) => volume_try_into_volume_mount(volume, container_name)
+            .wrap_err("error converting `volume` type volume mount"),
+        Mount::Bind(bind) => bind_try_into_volume_mount(bind, container_name)
+            .wrap_err("error converting `bind` type volume mount"),
+        Mount::Tmpfs(tmpfs) => tmpfs_try_into_volume_mount(tmpfs, container_name)
+            .wrap_err("error converting `tmpfs` type volume mount"),
+        Mount::NamedPipe(_) => Err(eyre!("`npipe` volume mount type is not supported")),
+        Mount::Cluster(_) => Err(eyre!("`cluster` volume mount type is not supported")),
+    }
+}
+
+/// Attempt to convert a [`mount::Volume`] into a [`VolumeMount`].
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is present.
+fn volume_try_into_volume_mount(
+    mount::Volume {
+        source,
+        volume,
+        common,
+    }: mount::Volume,
+    container_name: &Identifier,
+) -> color_eyre::Result<(VolumeMount, Volume)> {
+    ensure!(
+        volume.as_ref().map_or(true, VolumeOptions::is_empty),
+        "additional `volume` options are not supported"
+    );
+
+    let anonymous_volume = source.is_none();
+    let source = source.map_or(Source::Other { container_name }, Source::Volume);
+    let volume_mount = common_try_into_volume_mount(common, source)?;
+
+    let name = volume_mount.name.clone();
+    let volume = if anonymous_volume {
+        Volume {
+            name,
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Volume::default()
+        }
+    } else {
+        Volume {
+            name: name.clone(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: name,
+                read_only: None,
+            }),
+            ..Volume::default()
+        }
+    };
+
+    Ok((volume_mount, volume))
+}
+
+/// Attempt to convert a [`Bind`] volume [`Mount`] into a [`VolumeMount`].
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is present.
+fn bind_try_into_volume_mount(
+    Bind {
+        source,
+        bind,
+        common,
+    }: Bind,
+    container_name: &Identifier,
+) -> color_eyre::Result<(VolumeMount, Volume)> {
+    let BindOptions {
+        propagation,
+        create_host_path,
+        selinux,
+        extensions,
+    } = bind.unwrap_or_default();
+
+    ensure!(propagation.is_none(), "`bind.propagation` is not supported");
+    ensure!(
+        create_host_path,
+        "`bind.create_host_path: false` is not supported"
+    );
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let mut volume_mount = common_try_into_volume_mount(common, Source::Other { container_name })?;
+    if let Some(selinux) = selinux {
+        let mount_path = &mut volume_mount.mount_path;
+        mount_path.push(':');
+        mount_path.push(selinux.as_char());
+    }
+
+    let volume = Volume {
+        name: volume_mount.name.clone(),
+        host_path: Some(HostPathVolumeSource {
+            path: source
+                .into_inner()
+                .into_os_string()
+                .into_string()
+                .map_err(|_| eyre!("`source` must only contain valid UTF-8"))?,
+            type_: None,
+        }),
+        ..Volume::default()
+    };
+
+    Ok((volume_mount, volume))
+}
+
+/// Attempt to convert a [`Tmpfs`] volume [`Mount`] into a [`VolumeMount`].
+///
+/// # Errors
+///
+/// Returns an error if an unsupported option is present.
+fn tmpfs_try_into_volume_mount(
+    Tmpfs { tmpfs, common }: Tmpfs,
+    container_name: &Identifier,
+) -> color_eyre::Result<(VolumeMount, Volume)> {
+    let TmpfsOptions {
+        size,
+        mode,
+        extensions,
+    } = tmpfs.unwrap_or_default();
+
+    ensure!(mode.is_none(), "`tmpfs.mode` is not supported");
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let volume_mount = common_try_into_volume_mount(common, Source::Other { container_name })?;
+
+    let volume = Volume {
+        name: volume_mount.name.clone(),
+        empty_dir: Some(EmptyDirVolumeSource {
+            medium: Some("Memory".to_owned()),
+            size_limit: size.map(|size| Quantity(size.to_string())),
+        }),
+        ..Volume::default()
+    };
+
+    Ok((volume_mount, volume))
+}
+
+/// Attempt to convert [`Common`] volume [`Mount`] options into a [`VolumeMount`].
+///
+/// `source` is used to create the [`VolumeMount`]'s `name`.
+///
+/// # Errors
+///
+/// Returns an error if an unsupported [`Common`] option is present.
+fn common_try_into_volume_mount(
+    Common {
+        target,
+        read_only,
+        consistency,
+        extensions,
+    }: Common,
+    source: Source,
+) -> color_eyre::Result<VolumeMount> {
+    ensure!(consistency.is_none(), "`consistency` is not supported");
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    let mount_path = target
+        .into_inner()
+        .into_os_string()
+        .into_string()
+        .map_err(|_| eyre!("`target` must only contain valid UTF-8"))?;
+
+    let name = source.into_volume_name(&mount_path);
+
+    Ok(VolumeMount {
+        mount_path,
+        name,
+        read_only: read_only.then_some(true),
+        ..VolumeMount::default()
+    })
+}
+
+/// Source for a [`VolumeMount`].
+enum Source<'a> {
+    /// Source is a [`Volume`] with a [`PersistentVolumeClaimVolumeSource`].
+    Volume(Identifier),
+    /// Source is a [`Volume`] with some other source type.
+    Other { container_name: &'a Identifier },
+}
+
+impl<'a> Source<'a> {
+    /// Convert source into a `name` for a [`Volume`].
+    ///
+    /// If [`Other`](Self::Other), the `container_name` is combined with the `mount_path` to create
+    /// the `name`.
+    fn into_volume_name(self, mount_path: &str) -> String {
+        match self {
+            Self::Volume(volume) => volume.into(),
+            Self::Other { container_name } => {
+                format!("{container_name}{}", mount_path.replace(['/', '\\'], "-"))
+            }
+        }
+    }
+}

--- a/src/cli/k8s/volume.rs
+++ b/src/cli/k8s/volume.rs
@@ -1,0 +1,191 @@
+//! Utilities for converting a compose [`Volume`] into a Kubernetes [`PersistentVolumeClaim`].
+
+use color_eyre::eyre::{bail, ensure, Context};
+use compose_spec::{Identifier, MapKey, Number, StringOrNumber, Volume};
+use indexmap::IndexMap;
+use k8s_openapi::{
+    api::core::v1::PersistentVolumeClaim, apimachinery::pkg::apis::meta::v1::ObjectMeta,
+};
+
+/// Attempt to convert a compose [`Volume`] into a [`PersistentVolumeClaim`].
+///
+/// # Errors
+///
+/// Returns an error if the [`Volume`] has unsupported options set or there was an error converting
+/// an option.
+pub(super) fn try_into_persistent_volume_claim(
+    name: Identifier,
+    Volume {
+        driver,
+        driver_opts,
+        labels,
+        name: volume_name,
+        extensions,
+    }: Volume,
+) -> color_eyre::Result<PersistentVolumeClaim> {
+    ensure!(volume_name.is_none(), "`name` is not supported");
+    ensure!(
+        extensions.is_empty(),
+        "compose extensions are not supported"
+    );
+
+    Ok(PersistentVolumeClaim {
+        metadata: ObjectMeta {
+            name: Some(name.into()),
+            annotations: (driver.is_some() || !driver_opts.is_empty())
+                .then(|| {
+                    DriverOpts::try_from_compose(driver, driver_opts)
+                        .map(|driver_opts| driver_opts.into_annotations().collect())
+                })
+                .transpose()
+                .wrap_err("error converting `driver_opts`")?,
+            labels: (!labels.is_empty())
+                .then(|| {
+                    labels.into_map().map(|labels| {
+                        labels
+                            .into_iter()
+                            .map(|(key, value)| {
+                                (key.into(), value.map(Into::into).unwrap_or_default())
+                            })
+                            .collect()
+                    })
+                })
+                .transpose()
+                .wrap_err("error converting `labels`")?,
+            ..ObjectMeta::default()
+        },
+        spec: None,
+        status: None,
+    })
+}
+
+/// Supported volume driver options for a [`PersistentVolumeClaim`] through the use of Kubernetes
+/// annotations.
+///
+/// See the "Kubernetes Persistent Volume Claims" section of the docs for
+/// [**podman-kube-play**(1)](https://docs.podman.io/en/stable/markdown/podman-kube-play.1.html).
+#[derive(Debug, Default)]
+struct DriverOpts {
+    driver: Option<String>,
+    device: Option<String>,
+    fs_type: Option<String>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+    mount_options: Option<String>,
+    import_source: Option<String>,
+    image: Option<String>,
+}
+
+impl DriverOpts {
+    /// Attempt to create [`DriverOpts`] from a [`compose_spec::Volume`]'s `driver` and
+    /// `driver_opts` fields.
+    fn try_from_compose(
+        driver: Option<String>,
+        driver_opts: IndexMap<MapKey, StringOrNumber>,
+    ) -> color_eyre::Result<Self> {
+        driver_opts.into_iter().try_fold(
+            Self {
+                driver,
+                ..Self::default()
+            },
+            |mut driver_opts, (key, value)| {
+                driver_opts.parse_add(key.as_str(), value)?;
+                Ok(driver_opts)
+            },
+        )
+    }
+
+    /// Parse `key` as a driver option and add `value` to `self` as appropriate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `key` is an unknown option or there is an error converting the
+    /// `value`.
+    fn parse_add(&mut self, key: &str, value: StringOrNumber) -> color_eyre::Result<()> {
+        match key {
+            "device" => self.device = Some(value.into()),
+            "type" => self.fs_type = Some(value.into()),
+            "uid" => {
+                let StringOrNumber::Number(Number::UnsignedInt(uid)) = value else {
+                    bail!("`uid` must be a positive integer");
+                };
+                self.uid = uid
+                    .try_into()
+                    .map(Some)
+                    .wrap_err_with(|| format!("UID `{uid}` is too large"))?;
+            }
+            "gid" => {
+                let StringOrNumber::Number(Number::UnsignedInt(gid)) = value else {
+                    bail!("`gid` must be a positive integer");
+                };
+                self.gid = gid
+                    .try_into()
+                    .map(Some)
+                    .wrap_err_with(|| format!("GID `{gid}` is too large"))?;
+            }
+            "import-source" => self.import_source = Some(value.into()),
+            "image" => self.image = Some(value.into()),
+            "o" => {
+                let StringOrNumber::String(mount_options) = value else {
+                    bail!("`o` value must be a string");
+                };
+                self.add_mount_options(&mount_options)?;
+            }
+            key => bail!("unknown volume driver option `{key}`"),
+        }
+        Ok(())
+    }
+
+    /// Add the `mount_options` to `self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a `uid=` or `gid=` mount option value could not be parsed as a [`u32`].
+    fn add_mount_options(&mut self, mount_options: &str) -> color_eyre::Result<()> {
+        for mount_option in mount_options.split(',') {
+            if let Some(uid) = mount_option.strip_prefix("uid=") {
+                self.uid = uid.parse().map(Some).wrap_err_with(|| {
+                    format!("error parsing UID `{uid}` as an unsigned integer")
+                })?;
+            } else if let Some(gid) = mount_option.strip_prefix("gid=") {
+                self.gid = gid.parse().map(Some).wrap_err_with(|| {
+                    format!("error parsing GID `{gid}` as an unsigned integer")
+                })?;
+            } else if let Some(mount_options) = &mut self.mount_options {
+                mount_options.push(',');
+                mount_options.push_str(mount_option);
+            } else {
+                self.mount_options = Some(mount_option.to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert driver options into an [`Iterator`] of key-value pairs for use as
+    /// [`PersistentVolumeClaim`] annotations.
+    fn into_annotations(self) -> impl Iterator<Item = (String, String)> {
+        let Self {
+            driver,
+            device,
+            fs_type,
+            uid,
+            gid,
+            mount_options,
+            import_source,
+            image,
+        } = self;
+
+        [
+            ("volume.podman.io/driver", driver),
+            ("volume.podman.io/device", device),
+            ("volume.podman.io/type", fs_type),
+            ("volume.podman.io/uid", uid.as_ref().map(u32::to_string)),
+            ("volume.podman.io/gid", gid.as_ref().map(u32::to_string)),
+            ("volume.podman.io/mount-options", mount_options),
+            ("volume.podman.io/import-source", import_source),
+            ("volume.podman.io/image", image),
+        ]
+        .into_iter()
+        .filter_map(|(key, value)| value.map(|value| (key.to_owned(), value)))
+    }
+}

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -148,7 +148,7 @@ impl From<Create> for crate::quadlet::Network {
             ip_range: value.ip_range,
             ipv6: value.ipv6,
             label: value.label,
-            options: (!value.opt.is_empty()).then(|| value.opt.join(",")),
+            options: value.opt,
             podman_args: (!podman_args.is_empty()).then_some(podman_args),
             subnet: value.subnet,
         }

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -26,6 +26,7 @@ impl Display for Service {
     }
 }
 
+/*
 impl TryFrom<&docker_compose_types::Service> for Service {
     type Error = color_eyre::Report;
 
@@ -39,6 +40,7 @@ impl TryFrom<&docker_compose_types::Service> for Service {
         Ok(Self { restart })
     }
 }
+*/
 
 /// Possible service restart configurations
 ///

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -72,6 +72,7 @@ impl Unit {
         *self == Self::default()
     }
 
+    /*
     pub fn add_dependencies(&mut self, depends_on: docker_compose_types::DependsOnOptions) {
         let depends_on = match depends_on {
             docker_compose_types::DependsOnOptions::Simple(vec) => vec,
@@ -84,6 +85,7 @@ impl Unit {
                 .map(|dependency| dependency + ".service"),
         );
     }
+    */
 }
 
 impl Display for Unit {

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -42,6 +42,18 @@ pub struct Unit {
     )]
     requires: Vec<String>,
 
+    /// Similar to --requires, but when the dependency stops, this unit also stops
+    ///
+    /// Converts to "BindsTo=BINDS_TO[ ...]"
+    ///
+    /// Can be specified multiple times
+    #[arg(long)]
+    #[serde(
+        serialize_with = "quote_spaces_join_space",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    binds_to: Vec<String>,
+
     /// Configure ordering dependency between units
     ///
     /// Converts to "Before=BEFORE[ ...]"

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -80,8 +80,23 @@ pub struct Unit {
 }
 
 impl Unit {
+    /// Returns `true` if all fields are empty.
     pub fn is_empty(&self) -> bool {
-        *self == Self::default()
+        let Self {
+            description,
+            wants,
+            requires,
+            binds_to,
+            before,
+            after,
+        } = self;
+
+        description.is_none()
+            && wants.is_empty()
+            && requires.is_empty()
+            && binds_to.is_empty()
+            && before.is_empty()
+            && after.is_empty()
     }
 
     /*

--- a/src/cli/volume.rs
+++ b/src/cli/volume.rs
@@ -1,4 +1,4 @@
-pub mod opt;
+mod opt;
 
 use clap::{Args, Subcommand};
 

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -183,7 +183,7 @@ pub struct Container {
     pub notify: bool,
 
     /// Tune the container’s pids limit.
-    pub pids_limit: Option<i16>,
+    pub pids_limit: Option<Limit<u32>>,
 
     /// A list of arguments passed directly to the end of the `podman run` command
     /// in the generated file, right before the image name in the command line.
@@ -468,7 +468,7 @@ struct OptionsV4_7 {
     dns: Vec<String>,
     dns_option: Vec<String>,
     dns_search: Vec<String>,
-    pids_limit: Option<i16>,
+    pids_limit: Option<Limit<u32>>,
     shm_size: Option<String>,
     ulimit: Vec<String>,
 }

--- a/src/quadlet/container/device.rs
+++ b/src/quadlet/container/device.rs
@@ -180,7 +180,7 @@ impl From<service::Device> for Device {
     ) -> Self {
         Self {
             host,
-            container: Some(container),
+            container: Some(container.into_inner()),
             read,
             write,
             mknod,

--- a/src/quadlet/container/device.rs
+++ b/src/quadlet/container/device.rs
@@ -8,6 +8,7 @@ use std::{
     str::FromStr,
 };
 
+use compose_spec::service::{self, device::Permissions};
 use serde::{Serialize, Serializer};
 use thiserror::Error;
 
@@ -166,6 +167,24 @@ impl Display for Device {
 impl Serialize for Device {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(self)
+    }
+}
+
+impl From<service::Device> for Device {
+    fn from(
+        service::Device {
+            host_path: host,
+            container_path: container,
+            permissions: Permissions { read, write, mknod },
+        }: service::Device,
+    ) -> Self {
+        Self {
+            host,
+            container: Some(container),
+            read,
+            write,
+            mknod,
+        }
     }
 }
 

--- a/src/quadlet/container/mount.rs
+++ b/src/quadlet/container/mount.rs
@@ -11,6 +11,7 @@ use std::{
     str::FromStr,
 };
 
+use compose_spec::service::volumes::{mount, SELinux};
 use serde::{
     de::{
         self,
@@ -265,6 +266,21 @@ impl Display for BindPropagation {
     }
 }
 
+impl From<mount::BindPropagation> for BindPropagation {
+    fn from(value: mount::BindPropagation) -> Self {
+        match value {
+            mount::BindPropagation::Private => Self::Private,
+            mount::BindPropagation::Shared => Self::Shared,
+            mount::BindPropagation::Slave => Self::Slave,
+            mount::BindPropagation::Unbindable => Self::Unbindable,
+            mount::BindPropagation::RPrivate => Self::RPrivate,
+            mount::BindPropagation::RShared => Self::RShared,
+            mount::BindPropagation::RSlave => Self::RSlave,
+            mount::BindPropagation::RUnbindable => Self::RUnbindable,
+        }
+    }
+}
+
 /// SELinux relabeling.
 #[allow(clippy::doc_markdown)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -279,6 +295,15 @@ impl From<SELinuxRelabel> for char {
         match value {
             SELinuxRelabel::Shared => 'z',
             SELinuxRelabel::Private => 'Z',
+        }
+    }
+}
+
+impl From<SELinux> for SELinuxRelabel {
+    fn from(value: SELinux) -> Self {
+        match value {
+            SELinux::Shared => Self::Shared,
+            SELinux::Private => Self::Private,
         }
     }
 }

--- a/src/quadlet/kube.rs
+++ b/src/quadlet/kube.rs
@@ -198,16 +198,6 @@ pub enum YamlFile {
 }
 
 impl YamlFile {
-    /// Parse a [`YamlFile`] from a string.
-    fn parse<T>(file: T) -> Self
-    where
-        T: AsRef<str> + Into<PathBuf>,
-    {
-        file.as_ref()
-            .parse()
-            .map_or_else(|_| Self::Path(file.into()), Self::Url)
-    }
-
     /// Name of the kube file, without the extension.
     pub(crate) fn name(&self) -> Option<&str> {
         match self {
@@ -230,15 +220,15 @@ impl YamlFile {
     }
 }
 
-impl From<String> for YamlFile {
-    fn from(value: String) -> Self {
-        Self::parse(value)
+impl From<Url> for YamlFile {
+    fn from(value: Url) -> Self {
+        Self::Url(value)
     }
 }
 
-impl From<&str> for YamlFile {
-    fn from(value: &str) -> Self {
-        Self::parse(value)
+impl From<PathBuf> for YamlFile {
+    fn from(value: PathBuf) -> Self {
+        Self::Path(value)
     }
 }
 
@@ -246,7 +236,7 @@ impl FromStr for YamlFile {
     type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(s.into())
+        Ok(s.parse().map_or_else(|_| Self::Path(s.into()), Self::Url))
     }
 }
 
@@ -271,7 +261,7 @@ mod tests {
 
     #[test]
     fn kube_default_empty() {
-        let kube = Kube::new("yaml".into());
+        let kube = Kube::new(PathBuf::from("yaml").into());
         assert_eq!(kube.to_string(), "[Kube]\nYaml=yaml\n");
     }
 

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -101,11 +101,12 @@ impl Downgrade for Network {
     }
 }
 
-/*
-impl TryFrom<docker_compose_types::NetworkSettings> for Network {
+impl TryFrom<compose_spec::Network> for Network {
     type Error = color_eyre::Report;
 
-    fn try_from(value: docker_compose_types::NetworkSettings) -> Result<Self, Self::Error> {
+    fn try_from(value: compose_spec::Network) -> Result<Self, Self::Error> {
+        todo!()
+        /*
         let unsupported_options = [
             ("attachable", !value.attachable),
             ("internal", !value.internal),
@@ -164,9 +165,9 @@ impl TryFrom<docker_compose_types::NetworkSettings> for Network {
             label,
             ..Self::default()
         })
+        */
     }
 }
-*/
 
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -101,6 +101,7 @@ impl Downgrade for Network {
     }
 }
 
+/*
 impl TryFrom<docker_compose_types::NetworkSettings> for Network {
     type Error = color_eyre::Report;
 
@@ -165,6 +166,7 @@ impl TryFrom<docker_compose_types::NetworkSettings> for Network {
         })
     }
 }
+*/
 
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -5,7 +5,8 @@ use std::{
     str::FromStr,
 };
 
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre::{ensure, eyre, Context};
+use compose_spec::network::{Ipam, IpamConfig};
 use ipnet::IpNet;
 use serde::{Serialize, Serializer};
 use thiserror::Error;
@@ -55,7 +56,7 @@ pub struct Network {
     pub label: Vec<String>,
 
     /// Set driver specific options.
-    pub options: Option<String>,
+    pub options: Vec<String>,
 
     /// This key contains a list of arguments passed directly to the end of the `podman network create`
     /// command in the generated file, right before the name of the network in the command line.
@@ -104,68 +105,78 @@ impl Downgrade for Network {
 impl TryFrom<compose_spec::Network> for Network {
     type Error = color_eyre::Report;
 
-    fn try_from(value: compose_spec::Network) -> Result<Self, Self::Error> {
-        todo!()
-        /*
+    fn try_from(
+        compose_spec::Network {
+            driver,
+            driver_opts,
+            attachable,
+            enable_ipv6: ipv6,
+            ipam,
+            internal,
+            labels,
+            name,
+            extensions,
+        }: compose_spec::Network,
+    ) -> Result<Self, Self::Error> {
+        let Ipam {
+            driver: ipam_driver,
+            config: ipam_config,
+            options: ipam_options,
+            extensions: ipam_extensions,
+        } = ipam.unwrap_or_default();
+
         let unsupported_options = [
-            ("attachable", !value.attachable),
-            ("internal", !value.internal),
-            ("external", value.external.is_none()),
-            ("name", value.name.is_none()),
+            ("attachable", !attachable),
+            ("name", name.is_none()),
+            ("ipam.options", ipam_options.is_empty()),
         ];
         for (option, not_present) in unsupported_options {
-            eyre::ensure!(not_present, "`{option}` is not supported");
+            ensure!(not_present, "`{option}` is not supported");
         }
+        ensure!(
+            extensions.is_empty() && ipam_extensions.is_empty(),
+            "compose extensions are not supported"
+        );
 
-        let options: Vec<String> = value
-            .driver_opts
-            .into_iter()
-            .map(|(key, value)| {
-                let value = value.as_ref().map(ToString::to_string).unwrap_or_default();
-                format!("{key}={value}")
-            })
-            .collect();
-
-        let mut gateway = Vec::new();
-        let mut subnet = Vec::new();
-        let ipam_driver = value
-            .ipam
-            .map(|ipam| -> color_eyre::Result<_> {
-                for config in ipam.config {
-                    if let Some(ip) = config.gateway {
-                        gateway.push(ip.parse().wrap_err_with(|| {
-                            format!("could not parse `{ip}` as a valid IP address")
-                        })?);
-                    }
-                    subnet.push(config.subnet.parse().wrap_err_with(|| {
-                        format!("could not parse `{}` as a valid IP subnet", config.subnet)
-                    })?);
-                }
-                Ok(ipam.driver)
-            })
-            .transpose()
-            .wrap_err("invalid ipam config")?
-            .flatten();
-
-        let label = match value.labels {
-            docker_compose_types::Labels::List(labels) => labels,
-            docker_compose_types::Labels::Map(labels) => labels
+        let network = Self {
+            driver: driver.map(Into::into),
+            options: driver_opts
                 .into_iter()
                 .map(|(key, value)| format!("{key}={value}"))
                 .collect(),
+            ipv6,
+            ipam_driver,
+            internal,
+            label: labels.into_list().into_iter().collect(),
+            ..Self::default()
         };
 
-        Ok(Self {
-            driver: value.driver,
-            options: (!options.is_empty()).then(|| options.join(",")),
-            ipv6: value.enable_ipv6,
-            gateway,
-            subnet,
-            ipam_driver,
-            label,
-            ..Self::default()
-        })
-        */
+        ipam_config.into_iter().enumerate().try_fold(
+            network,
+            |mut network,
+             (
+                index,
+                IpamConfig {
+                    subnet,
+                    ip_range,
+                    gateway,
+                    aux_addresses,
+                    extensions,
+                },
+            )| {
+                if !aux_addresses.is_empty() {
+                    Err(eyre!("`aux_addresses` is not supported"))
+                } else if !extensions.is_empty() {
+                    Err(eyre!("compose extensions are not supported"))
+                } else {
+                    network.subnet.extend(subnet);
+                    network.ip_range.extend(ip_range.map(Into::into));
+                    network.gateway.extend(gateway);
+                    Ok(network)
+                }
+                .wrap_err_with(|| format!("error converting `ipam.config[{index}]`"))
+            },
+        )
     }
 }
 
@@ -182,6 +193,12 @@ pub enum IpRange {
     Cidr(IpNet),
     Ipv4Range(Range<Ipv4Addr>),
     Ipv6Range(Range<Ipv6Addr>),
+}
+
+impl From<IpNet> for IpRange {
+    fn from(value: IpNet) -> Self {
+        Self::Cidr(value)
+    }
 }
 
 impl Serialize for IpRange {

--- a/src/quadlet/volume.rs
+++ b/src/quadlet/volume.rs
@@ -99,11 +99,12 @@ impl Downgrade for Volume {
     }
 }
 
-/*
-impl TryFrom<docker_compose_types::ComposeVolume> for Volume {
+impl TryFrom<compose_spec::Volume> for Volume {
     type Error = color_eyre::Report;
 
-    fn try_from(value: docker_compose_types::ComposeVolume) -> Result<Self, Self::Error> {
+    fn try_from(value: compose_spec::Volume) -> Result<Self, Self::Error> {
+        todo!()
+        /*
         let unsupported_options = [
             ("external", value.external.is_none()),
             ("name", value.name.is_none()),
@@ -141,9 +142,9 @@ impl TryFrom<docker_compose_types::ComposeVolume> for Volume {
             label,
             ..options.into()
         })
+        */
     }
 }
-*/
 
 impl Display for Volume {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/quadlet/volume.rs
+++ b/src/quadlet/volume.rs
@@ -4,10 +4,10 @@ use std::{
     path::PathBuf,
 };
 
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre::{ensure, Context};
 use serde::Serialize;
 
-use crate::{cli::volume::opt::Opt, serde::quadlet::quote_spaces_join_space};
+use crate::{cli::volume::Opt, serde::quadlet::quote_spaces_join_space};
 
 use super::{Downgrade, DowngradeError, HostPaths, PodmanVersion};
 
@@ -102,47 +102,39 @@ impl Downgrade for Volume {
 impl TryFrom<compose_spec::Volume> for Volume {
     type Error = color_eyre::Report;
 
-    fn try_from(value: compose_spec::Volume) -> Result<Self, Self::Error> {
-        todo!()
-        /*
-        let unsupported_options = [
-            ("external", value.external.is_none()),
-            ("name", value.name.is_none()),
-        ];
-        for (option, not_present) in unsupported_options {
-            eyre::ensure!(not_present, "`{option}` is not supported");
-        }
+    fn try_from(
+        compose_spec::Volume {
+            driver,
+            driver_opts,
+            labels,
+            name,
+            extensions,
+        }: compose_spec::Volume,
+    ) -> Result<Self, Self::Error> {
+        ensure!(name.is_none(), "`name` is not supported");
+        ensure!(
+            extensions.is_empty(),
+            "compose extensions are not supported"
+        );
 
-        let options: Vec<Opt> = value
-            .driver_opts
+        let options: Vec<Opt> = driver_opts
             .into_iter()
-            .map(|(key, value)| {
-                let driver_opt = key.clone();
-                match value {
-                    Some(value) if key != "copy" => format!("{key}={value}"),
-                    _ => key,
-                }
-                .parse()
-                .wrap_err_with(|| {
-                    format!("driver_opt `{driver_opt}` is not a valid podman volume driver option")
-                })
+            .enumerate()
+            .map(|(index, (option, value))| {
+                let value = String::from(value);
+                let value = (!value.is_empty()
+                    && (option != "copy" || !matches!(value.as_str(), "true" | "1")))
+                .then_some(value);
+                Opt::parse(option.as_str(), value)
+                    .wrap_err_with(|| format!("error converting `driver_opts[{index}]`"))
             })
             .collect::<Result<_, _>>()?;
 
-        let label = match value.labels {
-            docker_compose_types::Labels::List(labels) => labels,
-            docker_compose_types::Labels::Map(labels) => labels
-                .into_iter()
-                .map(|(key, value)| format!("{key}={value}"))
-                .collect(),
-        };
-
         Ok(Self {
-            driver: value.driver,
-            label,
+            driver,
+            label: labels.into_list().into_iter().collect(),
             ..options.into()
         })
-        */
     }
 }
 

--- a/src/quadlet/volume.rs
+++ b/src/quadlet/volume.rs
@@ -99,6 +99,7 @@ impl Downgrade for Volume {
     }
 }
 
+/*
 impl TryFrom<docker_compose_types::ComposeVolume> for Volume {
     type Error = color_eyre::Report;
 
@@ -142,6 +143,7 @@ impl TryFrom<docker_compose_types::ComposeVolume> for Volume {
         })
     }
 }
+*/
 
 impl Display for Volume {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {


### PR DESCRIPTION
Changes the library used for deserializing a compose file from `docker-compose-types` to [`compose_spec`](https://github.com/k9withabone/compose_spec_rs). Most of the conversion logic was refactored/rewritten and hopefully readability and maintainability have improved in those areas. `compose_spec` is a lot stricter about what it accepts as a valid compose file. This is a **breaking change** as some compose files (those that don't comply with the spec) will no longer successfully deserialize and convert.

A new `--binds-to` option was added, which sets [`BindsTo=`](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#BindsTo=) in the `[Unit]` section. It was needed for converting from [long syntax `depends_on`](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#long-syntax-1) when `restart` is `true`.

One other **breaking change** is that `podlet compose --pod` was renamed to `podlet compose --kube` and no longer takes an argument. Instead, podlet uses the top-level `name` field from the compose file for the name of pod. `--pod` will return with Podman v5.0.0 support ([#68](https://github.com/containers/podlet/issues/68#issuecomment-2035489022)).

Closes #47
Closes #61
Closes #62
Closes #63
Closes #69