### PR TITLE
docs(changelog): fix v0.3.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2024-05-17
+## [0.3.0] - 2024-05-20
 
 Big release for Podlet!
 


### PR DESCRIPTION
The release of Podlet v0.3.0 was delayed by a few days, this updates the release date to today.