### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,29 +13,38 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
       - run: cargo fmt --verbose --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
       - run: cargo clippy -- -Dwarnings
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+
       - run: cargo test --verbose
 
   build-container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,23 @@ jobs:
 
       - run: cargo test --verbose
 
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo build --verbose
+      
   build-container:
+    needs: build
     runs-on: ubuntu-latest
     env:
       MANIFEST: podlet-multiarch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
 
   build-container:
     runs-on: ubuntu-latest
+    env:
+      MANIFEST: podlet-multiarch
     container:
       image: quay.io/containers/buildah:latest
       options: --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/fuse:rw
@@ -58,8 +60,16 @@ jobs:
 
       - run: buildah version
 
+      - name: Create manifest
+        run: |
+          buildah manifest create \
+            --annotation "org.opencontainers.image.source=https://github.com/containers/podlet" \
+            --annotation '"org.opencontainers.image.description=Generate Podman Quadlet files from a Podman command, compose file, or existing object"' \
+            --annotation "org.opencontainers.image.licenses=MPL-2.0" \
+            "${MANIFEST}"
+
       - name: Build ARM image
-        run: buildah build --platform linux/arm64/v8 -t podlet .
+        run: buildah build --manifest "${MANIFEST}" --platform linux/arm64/v8 -t podlet .
 
       - name: Build x86 image
-        run: buildah build --platform linux/amd64 -t podlet .
+        run: buildah build --manifest "${MANIFEST}" --platform linux/amd64 -t podlet .

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           buildah manifest create \
             --annotation "org.opencontainers.image.source=https://github.com/containers/podlet" \
-            --annotation "org.opencontainers.image.description=Generate Podman Quadlet files from a Podman command, compose file, or existing object" \
+            --annotation '"org.opencontainers.image.description=Generate Podman Quadlet files from a Podman command, compose file, or existing object"' \
             --annotation "org.opencontainers.image.licenses=MPL-2.0" \
             "${MANIFEST}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2024-05-20
+## [0.3.0] - 2024-05-21
 
 Big release for Podlet!
 
@@ -54,6 +54,7 @@ Note that the existing option for generating Kubernetes Pod YAML from a Compose 
 - *(container)* Enforce `--blkio-weight` range `10..=1000`.
 - *(container)* `--blkio-weight-device` can be specified multiple times.
 - *(container)* Don't add empty `PodmanArgs=` when downgrading Podman version.
+- Correct use of `eyre::bail!()` on non-Unix platforms.
 
 ### Documentation
 - *(clippy)* Fix Clippy lint warning for `Idmap`.
@@ -101,6 +102,10 @@ Note that the existing option for generating Kubernetes Pod YAML from a Compose 
 - *(ci)* Use Buildah container to build Podlet container.
 - *(deps)* Update dependencies.
 - *(release)* Update cargo-dist.
+- *(release-container)* Fix manifest annotation quoting.
+- *(ci)* Use consistent formatting.
+- *(ci)* Add image to manifest when building container.
+- *(ci)* Add `build` job.
 
 ## [0.2.4] - 2024-01-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,9 @@ below is a list of all the jobs with explanations and the commands that they run
   - Unit tests are defined in the source.
   - All tests should pass.
   - `cargo test`
+- build:
+  - Ensures Podlet can build on all target platforms.
+  - `cargo build`
 - build-container:
   - Ensures that the [Podlet container](./Containerfile) can build for both x86 and ARM platforms.
   - First, [install Buildah](https://github.com/containers/buildah/blob/main/install.md).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,7 +211,7 @@ impl Cli {
             }
 
             #[cfg(not(unix))]
-            eyre::bail!("Cannot get Podman unit directory on non-unix system");
+            color_eyre::eyre::bail!("Cannot get Podman unit directory on non-Unix system");
         } else if let Some(Some(path)) = &self.file {
             if path.is_dir() {
                 path.clone()


### PR DESCRIPTION
A minor fix for the `release-container` CI.  Changed the `build-container` CI job to hopefully catch any similar issues in the future.

Added a `build` job to the CI to ensure Podlet builds on all supported platforms: Linux, Windows, and macOS.

Minor fix in `Cli::file_path()` for non-Unix platforms (i.e. Windows).

I'll merge this and publish Podlet v0.3.0 tomorrow unless someone raises an objection.