### PR TITLE
ci(release-container): add `--all` to `buildah manifest push`

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -42,9 +42,9 @@ jobs:
           USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          buildah manifest push "${MANIFEST}:latest" \
+          buildah manifest push "${MANIFEST}:latest" --all \
             --creds "${USERNAME}:${PASSWORD}" \
             "docker://ghcr.io/containers/podlet:${GITHUB_REF_NAME}" && \
-          buildah manifest push "${MANIFEST}:latest" \
+          buildah manifest push "${MANIFEST}:latest" --all \
             --creds "${USERNAME}:${PASSWORD}" \
             "docker://ghcr.io/containers/podlet:latest"


### PR DESCRIPTION
The `--all` option is not true by default for `buildah manifest push` like it is for `podman manifest push`. `--all` makes Buildah push the images in addition to the manifest.

Fixes: #82