### PR TITLE
fix(compose): prepend container dependencies with pod name

### DIFF
--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -113,7 +113,7 @@ impl Unit {
     /// or the [`Dependency`] is set to `restart` but is not `required`.
     pub fn add_dependency(
         &mut self,
-        name: impl Display,
+        mut name: String,
         Dependency {
             condition,
             restart,
@@ -141,7 +141,7 @@ impl Unit {
             (false, false) => &mut self.wants,
         };
 
-        let name = format!("{name}.service");
+        name.push_str(".service");
         list.push(name.clone());
         self.after.push(name);
 


### PR DESCRIPTION
When the `podlet compose --pod` option is used, the names of the services from the Compose file are prepended with the pod name. If a service had a dependency via the `depends_on` attribute, the name of the dependency was not similarly prepended with the pod name when added to the `[Unit]` section of the Quadlet file.

Changed `podlet::cli::compose::service_try_into_quadlet_file()` to handle all service name changes when the `--pod` option is used.

Fixes: #114