### PR TITLE
fix(container): support short flag `-h` for `podman run --hostname`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use clap::{builder::TypedValueParser, Parser, Subcommand};
+use clap::{builder::TypedValueParser, ArgAction, Parser, Subcommand};
 use color_eyre::{
     eyre::{ensure, eyre, WrapErr},
     Help,
@@ -399,6 +399,7 @@ enum PodmanCommands {
     ///
     /// For details on options see:
     /// https://docs.podman.io/en/stable/markdown/podman-systemd.unit.5.html
+    #[command(disable_help_flag = true)]
     Run {
         /// The \[Container\] section
         #[command(flatten)]
@@ -407,6 +408,17 @@ enum PodmanCommands {
         /// The \[Service\] section
         #[command(flatten)]
         service: Service,
+
+        /// Print help
+        // Changed from default to support `podman run -h`, i.e. `podman run --hostname`.
+        #[arg(
+            short = '?',
+            long,
+            action = ArgAction::Help,
+            help = "Print help (see more with '--help')",
+            long_help = "Print help (see a summary with '-?')"
+        )]
+        help: (),
     },
 
     /// Generate a Podman Quadlet `.pod` file

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -230,7 +230,7 @@ pub struct QuadletOptions {
     /// Set the host name that is available inside the container
     ///
     /// Converts to "HostName=NAME"
-    #[arg(long, value_name = "NAME")]
+    #[arg(short, long, value_name = "NAME")]
     hostname: Option<String>,
 
     /// Specify a static IPv4 address for the container

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -164,7 +164,7 @@ impl Generate {
 
 /// [`Parser`] for container creation CLI options.
 #[derive(Parser, Debug)]
-#[command(no_binary_name = true)]
+#[command(no_binary_name = true, disable_help_flag = true)]
 struct ContainerParser {
     /// Podman global options
     #[command(flatten)]
@@ -284,7 +284,7 @@ impl ContainerInspect {
 
 /// [`Parser`] for pod creation CLI options.
 #[derive(Parser, Debug)]
-#[command(no_binary_name = true)]
+#[command(no_binary_name = true, disable_help_flag = true)]
 struct PodParser {
     /// Podman global options
     #[command(flatten)]
@@ -873,5 +873,10 @@ mod tests {
     #[test]
     fn verify_container_parser_cli() {
         ContainerParser::command().debug_assert();
+    }
+
+    #[test]
+    fn verify_pod_parser_cli() {
+        PodParser::command().debug_assert();
     }
 }


### PR DESCRIPTION
Changed short help flag to `-?` for `podlet podman run`. This could be a potentially minor breaking change for some users.

Fixes: #105