### PR TITLE
fix(compose): `.build` Quadlet file error reporting

### DIFF
--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -347,6 +347,9 @@ fn services_try_into_quadlet_files<'a>(
                 install: install.cloned(),
             })
         });
+        if let Some(result @ Err(_)) = build {
+            return iter::once(result).chain(None);
+        }
 
         let container = service_try_into_quadlet_file(
             service,


### PR DESCRIPTION
If there was an error converting the `build` section of a Compose service it would not be reported to the user. The rest of the service would fail to convert to a `.container` Quadlet file as the `image` would not be set (it's set after the `build` section is successfully converted). The user would receive a "`image` or `build` is required" error as the service error would be reported first.

Changed `podlet::cli::compose::services_try_into_quadlet_files()` so that if an error occurs when converting the `build` section, it is reported to the user without attempting to convert the rest of the service.

Fixes: #126