### PR TITLE
feat: missing tag default to latest

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -358,8 +358,8 @@ impl TryFrom<service::Build> for Build {
         let mut tags = tags.into_iter();
         let tag = tags
             .next()
-            .ok_or_eyre("an image tag is required")?
-            .into_inner();
+            .map(|t| t.into_inner())
+            .unwrap_or_else(|| "latest".to_string());
         ensure!(
             tags.next().is_none(),
             "Quadlet only supports setting a single tag"


### PR DESCRIPTION
 ## Description

I was playing with some compose file from the https://github.com/docker/awesome-compose repository. And some of them, very simple (too simple) where failing because some properties where missing such as `Service#build#tags`

When no value is provided `( podman | docker ) compose up` use `latest`, can we do the same here ?