### PR TITLE
fix(compose): support explicit network names

### DIFF
--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -175,7 +175,7 @@ impl From<Create> for crate::quadlet::Network {
             ip_range,
             ipv6,
             label,
-            name: None,
+            network_name: None,
             options: opt,
             podman_args: (!podman_args.is_empty()).then_some(podman_args),
             subnet,

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -175,6 +175,7 @@ impl From<Create> for crate::quadlet::Network {
             ip_range,
             ipv6,
             label,
+            name: None,
             options: opt,
             podman_args: (!podman_args.is_empty()).then_some(podman_args),
             subnet,

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -86,6 +86,14 @@ impl Downgrade for Network {
         }
 
         if version < PodmanVersion::V4_7 {
+            if let Some(name) = self.name.take() {
+                return Err(DowngradeError::Option {
+                    quadlet_option: "NetworkName",
+                    value: name,
+                    supported_version: PodmanVersion::V4_7,
+                });
+            }
+
             for dns in std::mem::take(&mut self.dns) {
                 self.push_arg("dns", &dns);
             }
@@ -287,6 +295,33 @@ mod tests {
             crate::serde::quadlet::to_string_join_all(network)?,
             "[Network]\nNetworkName=explicit-network-name\n"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn network_name_added_in_v4_7() -> color_eyre::Result<()> {
+        let mut network = Network {
+            name: Some("explicit-network-name".into()),
+            ..Network::default()
+        };
+
+        let error = network
+            .downgrade(PodmanVersion::V4_6)
+            .err()
+            .ok_or_else(|| eyre!("expected NetworkName to be rejected before Podman v4.7"))?;
+
+        assert_eq!(
+            error.to_string(),
+            "Quadlet option `NetworkName=explicit-network-name` was not supported until Podman v4.7"
+        );
+
+        let mut network = Network {
+            name: Some("explicit-network-name".into()),
+            ..Network::default()
+        };
+
+        network.downgrade(PodmanVersion::V4_7)?;
+        assert_eq!(network.name.as_deref(), Some("explicit-network-name"));
         Ok(())
     }
 }

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -54,6 +54,10 @@ pub struct Network {
     #[serde(serialize_with = "seq_quote_whitespace")]
     pub label: Vec<String>,
 
+    /// Override the name of the Podman network created by this Quadlet.
+    #[serde(rename = "NetworkName")]
+    pub name: Option<String>,
+
     /// Set driver specific options.
     pub options: Vec<String>,
 
@@ -126,7 +130,6 @@ impl TryFrom<compose_spec::Network> for Network {
 
         let unsupported_options = [
             ("attachable", !attachable),
-            ("name", name.is_none()),
             ("ipam.options", ipam_options.is_empty()),
         ];
         for (option, not_present) in unsupported_options {
@@ -147,6 +150,7 @@ impl TryFrom<compose_spec::Network> for Network {
             ipam_driver,
             internal,
             label: labels.into_list().into_iter().collect(),
+            name,
             ..Self::default()
         };
 
@@ -267,6 +271,21 @@ mod tests {
         assert_eq!(
             crate::serde::quadlet::to_string_join_all(network)?,
             "[Network]\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn compose_network_name() -> Result<(), crate::serde::quadlet::Error> {
+        let network = compose_spec::Network {
+            name: Some("explicit-network-name".into()),
+            ..compose_spec::Network::default()
+        };
+        let network = Network::try_from(network).unwrap();
+
+        assert_eq!(
+            crate::serde::quadlet::to_string_join_all(network)?,
+            "[Network]\nNetworkName=explicit-network-name\n"
         );
         Ok(())
     }

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -55,8 +55,8 @@ pub struct Network {
     pub label: Vec<String>,
 
     /// Override the name of the Podman network created by this Quadlet.
-    #[serde(rename = "NetworkName")]
-    pub name: Option<String>,
+    #[expect(clippy::struct_field_names, reason = "Quadlet option")]
+    pub network_name: Option<String>,
 
     /// Set driver specific options.
     pub options: Vec<String>,
@@ -86,10 +86,10 @@ impl Downgrade for Network {
         }
 
         if version < PodmanVersion::V4_7 {
-            if let Some(name) = self.name.take() {
+            if let Some(network_name) = self.network_name.take() {
                 return Err(DowngradeError::Option {
                     quadlet_option: "NetworkName",
-                    value: name,
+                    value: network_name,
                     supported_version: PodmanVersion::V4_7,
                 });
             }
@@ -125,7 +125,7 @@ impl TryFrom<compose_spec::Network> for Network {
             ipam,
             internal,
             labels,
-            name,
+            name: network_name,
             extensions,
         }: compose_spec::Network,
     ) -> Result<Self, Self::Error> {
@@ -158,7 +158,7 @@ impl TryFrom<compose_spec::Network> for Network {
             ipam_driver,
             internal,
             label: labels.into_list().into_iter().collect(),
-            name,
+            network_name,
             ..Self::default()
         };
 
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn network_name_added_in_v4_7() -> color_eyre::Result<()> {
         let mut network = Network {
-            name: Some("explicit-network-name".into()),
+            network_name: Some("explicit-network-name".into()),
             ..Network::default()
         };
 
@@ -316,12 +316,15 @@ mod tests {
         );
 
         let mut network = Network {
-            name: Some("explicit-network-name".into()),
+            network_name: Some("explicit-network-name".into()),
             ..Network::default()
         };
 
         network.downgrade(PodmanVersion::V4_7)?;
-        assert_eq!(network.name.as_deref(), Some("explicit-network-name"));
+        assert_eq!(
+            network.network_name.as_deref(),
+            Some("explicit-network-name")
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- accept the Compose `name` field on top-level network definitions
- emit the explicit name as `NetworkName=` in the generated Quadlet network unit
- add regression coverage for the conversion

## Why

Compose allows a network resource key and the created network's name to differ:

```yaml
networks:
  backend:
    name: explicit-network-name
```

Podlet 0.3.2 currently rejects this input because the Quadlet network conversion classifies `name` as unsupported. Mapping it to `NetworkName=` preserves the resource key for the generated `backend.network` file and its container references while creating the Podman network with the requested explicit name.

This implements the behavior described in #21.

## Validation

- `cargo fmt --verbose --check`
- `cargo clippy -- -Dwarnings`
- `cargo test --verbose` (78 passed)
- end-to-end Compose conversion confirmed `Network=backend.network` and `NetworkName=explicit-network-name`
