### PR TITLE
Update shlex dependency to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ path-clean = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.21"
-shlex = "1.3"
+shlex = "2.0"
 smart-default = "0.7"
 thiserror = "1.0.40"
 umask = "2.1.0"


### PR DESCRIPTION
See https://github.com/comex/rust-shlex/blob/653936e120cdd0a8d1b4f0837e2cce0f347da4c0/CHANGELOG.md. There are only three calls into `shlex`, and they don’t use any of the APIs that were removed in v2:

https://github.com/containers/podlet/blob/74ba158ee3b96e215c3aa74e8b64d2f39903fb9a/src/escape.rs#L36

https://github.com/containers/podlet/blob/74ba158ee3b96e215c3aa74e8b64d2f39903fb9a/src/escape.rs#L41

https://github.com/containers/podlet/blob/74ba158ee3b96e215c3aa74e8b64d2f39903fb9a/src/cli/compose.rs#L32